### PR TITLE
`giveaway` plugin v2.1.0

### DIFF
--- a/giveaway/core/checks.py
+++ b/giveaway/core/checks.py
@@ -14,7 +14,6 @@ def can_execute_giveaway(ctx: commands.Context, destination: discord.TextChannel
     attrs = [
         "send_messages",
         "read_message_history",
-        "manage_messages",
         "embed_links",
         "add_reactions",
     ]

--- a/giveaway/core/views.py
+++ b/giveaway/core/views.py
@@ -175,10 +175,10 @@ class GiveawayView(View):
         try:
             winners = int(winners)
         except ValueError:
-            errors.append("Unable to parse giveaway winners to numbers.")
+            errors.append("Unable to convert giveaway winners to numbers.")
         else:
-            if winners < 0:
-                errors.append("Giveaway can only be held with 1 or more winners.")
+            if not 1 <= winners <= 50:
+                errors.append("Giveaway can only be held with 1 up to 50 winners.")
             else:
                 self.giveaway_winners = winners
 

--- a/giveaway/giveaway.py
+++ b/giveaway/giveaway.py
@@ -179,6 +179,8 @@ class Giveaway(commands.Cog):
                 "Need `SEND_MESSAGES`, `READ_MESSAGES`, `MANAGE_MESSAGES`, "
                 f"`EMBED_LINKS`, and `ADD_REACTIONS` permissions in {ch_text}."
             )
+        if len(self.active_giveaways) >= 15:
+            raise commands.BadArgument("Only 15 active giveaways are allowed at the same time.")
 
         view = GiveawayView(ctx)
         embed = discord.Embed(

--- a/giveaway/giveaway.py
+++ b/giveaway/giveaway.py
@@ -160,6 +160,11 @@ class Giveaway(commands.Cog):
     async def giveaway(self, ctx: commands.Context):
         """
         Create / Stop Giveaways.
+        
+        _**Notes:**_
+        - Make sure the bot has these permissions in your Giveaway channel:
+        `View Channel`, `Send Messages`, `Read Message History`, `Embed Links`, and `Add Reactions`.
+        - Only 15 active giveaways are allowed at a time.
         """
         await ctx.send_help(ctx.command)
 
@@ -176,8 +181,8 @@ class Giveaway(commands.Cog):
             if ctx.channel != channel:
                 ch_text += f" and {channel.mention} channel"
             raise commands.BadArgument(
-                "Need `SEND_MESSAGES`, `READ_MESSAGES`, `MANAGE_MESSAGES`, "
-                f"`EMBED_LINKS`, and `ADD_REACTIONS` permissions in {ch_text}."
+                "Need `Send Messaged`, `Read Message History`, "
+                f"`Embed Links`, and `Add Reactions` permissions in {ch_text}."
             )
         if len(self.active_giveaways) >= 15:
             raise commands.BadArgument("Only 15 active giveaways are allowed at the same time.")
@@ -311,7 +316,7 @@ class Giveaway(commands.Cog):
         session.force_stop()
         self.active_giveaways.remove(session)
         await self._update_db()
-        await ctx.send("Cancelled!")
+        await ctx.send(f"Giveaway ID `{message_id}` is now cancelled!")
 
     @giveaway.command(name="list")
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)

--- a/giveaway/giveaway.py
+++ b/giveaway/giveaway.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, TYPE_CHECKING
 
@@ -309,6 +310,31 @@ class Giveaway(commands.Cog):
         self.active_giveaways.remove(session)
         await self._update_db()
         await ctx.send("Cancelled!")
+
+    @giveaway.command(name="list")
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
+    async def gaway_list(self, ctx: commands.Context):
+        """
+        Show the list of active giveaways.
+        """
+        embed = discord.Embed(title="Active giveaways", color=self.bot.main_color)
+        desc = ""
+        n = 0
+        for session in self.active_giveaways:
+            n += 1
+            message = session.message
+            if not message:
+                message = await session.channel.fetch_message(session.id)
+            desc += (
+                f"[Giveaway {n}]({message.jump_url})\n"
+                f"End: {discord.utils.format_dt(datetime.fromtimestamp(session.ends), 'R')}\n\n"
+            )
+
+        if not desc:
+            desc = "No active giveaways."
+        embed.description = desc
+
+        await ctx.send(embed=embed)
 
     @commands.Cog.listener()
     async def on_giveaway_end(self, session: GiveawaySession) -> None:

--- a/giveaway/giveaway.py
+++ b/giveaway/giveaway.py
@@ -161,7 +161,7 @@ class Giveaway(commands.Cog):
         """
         Create / Stop Giveaways.
 
-        _**Notes:**_
+        __**Notes:**__
         - Make sure the bot has these permissions in your Giveaway channel:
         `View Channel`, `Send Messages`, `Read Message History`, `Embed Links`, and `Add Reactions`.
         - Only 15 active giveaways are allowed at a time.

--- a/giveaway/giveaway.py
+++ b/giveaway/giveaway.py
@@ -189,7 +189,7 @@ class Giveaway(commands.Cog):
                 "See the notes below for additional info."
             ),
         )
-        embed.add_field(name="Winners count", value="Must be integers and can only be 3 digits or lower.")
+        embed.add_field(name="Winners count", value="Must be integers between 1 to 50.")
         embed.add_field(name="Duration syntax", value=duration_syntax)
         embed.set_footer(text="This view will time out after 10 minutes.")
         view.message = await ctx.send(embed=embed, view=view)

--- a/giveaway/giveaway.py
+++ b/giveaway/giveaway.py
@@ -160,7 +160,7 @@ class Giveaway(commands.Cog):
     async def giveaway(self, ctx: commands.Context):
         """
         Create / Stop Giveaways.
-        
+
         _**Notes:**_
         - Make sure the bot has these permissions in your Giveaway channel:
         `View Channel`, `Send Messages`, `Read Message History`, `Embed Links`, and `Add Reactions`.

--- a/giveaway/info.json
+++ b/giveaway/info.json
@@ -5,7 +5,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0"
 }


### PR DESCRIPTION
__**List of changes:**__
- Limit winners to 50.
- Limit 15 active giveaways at a time (performance purpose).
- Add `giveaway list` command.
- Remove `Manage Messages` from permission check.
- Update docs and error messages.