### PR TITLE
`rolemanager` plugin v2.0.0

### DIFF
--- a/rolemanager/core/config.py
+++ b/rolemanager/core/config.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 _default_config: ConfigPayload = {
-    "autorole": {
+    "autoroles": {
         "roles": [],
         "enable": False,
     },
@@ -39,11 +39,13 @@ def _resolve_migration(data: Dict[str, Any]) -> bool:
                     if g in v[msg_id]:
                         v[msg_id]["binds"] = v[msg_id].pop(g)
                         update = True
+                    trigger_type = v[msg_id].get("type")
+                    if not trigger_type:
+                        v[msg_id]["type"] = "REACTION"
         if key == "autorole":
             data["autoroles"] = data.pop("autorole")
         if key == "reactroles":
             if data[key].get("channels", None) is not None:
-                data[key]["message_cache"] = {}
                 data[key].pop("channels")
                 update = True
     return update

--- a/rolemanager/core/config.py
+++ b/rolemanager/core/config.py
@@ -48,6 +48,14 @@ def _resolve_migration(data: Dict[str, Any]) -> bool:
             if data[key].get("channels", None) is not None:
                 data[key].pop("channels")
                 update = True
+            rr_msgs = data[key]["message_cache"]
+            for msg_id in list(rr_msgs):
+                binds = rr_msgs[msg_id].get("binds", {})
+                flipped = None
+                if any(not k.isdigit() for k, _ in binds.items()):
+                    flipped = {str(v): {"emoji": k} for k, v in binds.items()}
+                if flipped is not None:
+                    data[key]["message_cache"][msg_id]["binds"] = flipped
     return update
 
 
@@ -65,7 +73,11 @@ class RoleManagerConfig(Config):
         data = await super().fetch()
         if data is None:
             data = self.deepcopy(_default_config)
-        identifier = "autorole" in data or data["reactroles"].get("channels", None) is not None
+        identifier = (
+            "autorole" in data
+            or data["reactroles"].get("channels", None) is not None
+            or any(val.get("type", None) is None for val in data["reactroles"]["message_cache"])
+        )
         if identifier:
             _resolve_migration(data)
             await self.update(data=data)

--- a/rolemanager/core/config.py
+++ b/rolemanager/core/config.py
@@ -24,7 +24,7 @@ _default_config: ConfigPayload = {
 
 
 # TODO: Deprecate
-def _resolve_migration(data) -> bool:
+def _resolve_migration(data: Dict[str, Any]) -> bool:
     update = False
     for key, elems in list(data.items()):
         if not isinstance(elems, dict):

--- a/rolemanager/core/models.py
+++ b/rolemanager/core/models.py
@@ -177,7 +177,6 @@ class ReactionRoleManager:
 
     def __init__(self, cog: RoleManager, *, data: ReactRoleConfigPayload):
         self.cog: RoleManager = cog
-        self.channels: List[str] = data.pop("channels", [])
         self._enable: bool = data.pop("enable", True)
         self.entries: Set[ReactionRole] = set()
 
@@ -354,7 +353,6 @@ class ReactionRoleManager:
         if unresolved:
             message_cache.update(unresolved)
         return {
-            "channels": self.channels,
             "enable": self.is_enabled(),
             "message_cache": message_cache,
         }

--- a/rolemanager/core/models.py
+++ b/rolemanager/core/models.py
@@ -106,7 +106,7 @@ class ReactionRole:
     message : Union[discord.PartialMessage, discord.Message]
         The message where the reactions are attached to.
     binds : Dict[str, Any]
-        Role button mapping. Key would be role ID and value would be a dicttionary
+        Role button mapping. Key would be role ID and value would be a dictionary
         of button values.
     rules : str
         The rules applied for the reactions.

--- a/rolemanager/core/models.py
+++ b/rolemanager/core/models.py
@@ -102,8 +102,9 @@ class ReactionRole:
     ----------
     message : Union[discord.PartialMessage, discord.Message]
         The message where the reactions are attached to.
-    binds : Dict[str, str]
-        Emoji role mapping.
+    binds : Dict[str, Any]
+        Role button mapping. Key would be role ID and value would be a dicttionary
+        of button values.
     rules : str
         The rules applied for the reactions.
     """
@@ -117,8 +118,9 @@ class ReactionRole:
     ):
         self.message: Union[discord.PartialMessage, discord.Message] = message
         self.channel: discord.TextChannel = message.channel
-        self.binds: Dict[str, str] = binds
+        self.binds: Dict[str, Any] = binds
         self.rules: str = rules
+        self.view = None
 
     def __hash__(self):
         return hash((self.message.id, self.channel.id))

--- a/rolemanager/core/types.py
+++ b/rolemanager/core/types.py
@@ -16,7 +16,6 @@ MessageCachePayload = Dict[str, ReactRolePayload]
 
 class ReactRoleConfigPayload(TypedDict):
     message_cache: MessageCachePayload
-    channels: List[int]
     enable: bool
 
 

--- a/rolemanager/core/utils.py
+++ b/rolemanager/core/utils.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import discord
 
 
-async def delete_quietly(message: discord.Message):
+if TYPE_CHECKING:
+    from bot import ModmailBot
+
+
+async def delete_quietly(message: discord.Message) -> None:
     if message.channel.permissions_for(message.guild.me).manage_messages:
         try:
             await message.delete()
@@ -11,3 +19,11 @@ async def delete_quietly(message: discord.Message):
 
 def guild_roughly_chunked(guild: discord.Guild) -> bool:
     return len(guild.members) / guild.member_count > 0.9
+
+
+def error_embed(bot: ModmailBot, *, description: str) -> discord.Embed:
+    return discord.Embed(
+        title="__Errors__",
+        color=bot.error_color,
+        description=description,
+    )

--- a/rolemanager/core/views.py
+++ b/rolemanager/core/views.py
@@ -223,8 +223,6 @@ class ReactionRoleCreationPanel(RoleManagerView):
                 continue
             if label in ("done", "clear"):
                 child.disabled = len(self.binds) < 1
-            # elif label == "preview":
-            #     child.disabled = not self.output_embed or len(self.output_embed) < 1
             elif label == "add":
                 child.disabled = not self.current_input.get("converted", False)
             else:

--- a/rolemanager/core/views.py
+++ b/rolemanager/core/views.py
@@ -146,15 +146,14 @@ class ReactionRoleCreationPanel(RoleManagerView):
         ctx: commands.Context,
         *,
         input_sessions: List[Tuple[[str, Any]]],
-        rule: str = MISSING,
         binds: Dict[str, Any] = MISSING,
     ):
         self.ctx: commands.Context = ctx
         self.user: discord.Member = ctx.author
         self.input_sessions: List[Tuple[[str, Any]]] = input_sessions
         self.current_input: Dict[str, Any] = {}  # keys would be emoji, label, role, color
-        self.current_index: int = 0
-        self.rule: Optional[str] = rule
+        self.__index: int = 0
+        self.rule: str = MISSING
         self.output_embed: discord.Embed = MISSING
         self.placeholder_description: str = MISSING
         self.binds: Dict[str, Any] = binds if binds else {}
@@ -230,11 +229,11 @@ class ReactionRoleCreationPanel(RoleManagerView):
 
     @property
     def session_key(self) -> str:
-        return self.input_sessions[self.current_index]["key"]
+        return self.input_sessions[self.__index]["key"]
 
     @property
     def session_description(self) -> str:
-        return self.input_sessions[self.current_index]["description"]
+        return self.input_sessions[self.__index]["description"]
 
     def _parse_output_description(self, *, buttons: List[Button] = None) -> str:
         desc = self.placeholder_description
@@ -343,7 +342,7 @@ class ReactionRoleCreationPanel(RoleManagerView):
 
     async def _action_done(self, interaction: Interaction, *args) -> None:
         await interaction.response.defer()
-        self.current_index += 1
+        self.__index += 1
         if self.output_embed:
             self.output_embed.description = self._parse_output_description(buttons=self.get_output_buttons())
         self.clear_items()
@@ -369,7 +368,7 @@ class ReactionRoleCreationPanel(RoleManagerView):
         if category == "rule":
             select.disabled = True
             self.rule = option.value
-            self.current_index += 1
+            self.__index += 1
             embed = self.message.embeds[0]
             embed.description = self.session_description
             self.clear_items()

--- a/rolemanager/core/views.py
+++ b/rolemanager/core/views.py
@@ -241,7 +241,7 @@ class ReactionRoleCreationPanel(RoleManagerView):
             return desc
         for button in buttons:
             prefix = f"{str(button.emoji)} " if button.emoji else ""
-            desc += f"> **{prefix}{button.label}** - <@&{button.custom_id}>\n"
+            desc += f"- **{prefix}{button.label}** : <@&{button.custom_id}>\n"
         return desc
 
     def get_output_buttons(self) -> List[Button]:

--- a/rolemanager/core/views.py
+++ b/rolemanager/core/views.py
@@ -306,15 +306,23 @@ class ReactionRoleCreationPanel(RoleManagerView):
         role = self.current_input.pop("role")
         emoji = self.current_input.pop("emoji")
         binds = {"emoji": str(emoji) if emoji else None}
+        label = self.current_input.pop("label", None)
         if self.trigger_type == TriggerType.INTERACTION:
             binds.update(
-                label=self.current_input.pop("label"),
+                label=label,
                 style=self.current_input.pop("style", "blurple"),
             )
 
         self.binds[str(role.id)] = binds
         self.current_input.clear()
-        await interaction.response.send_message(f"Added role {role.mention}.", ephemeral=True)
+        prefix = f"{emoji} " if emoji else ""
+        if label is None:
+            label = ""
+        embed = discord.Embed(
+            color=self.ctx.bot.main_color,
+            description=f"Added '{prefix}{label} : {role.mention}' bind to the list.",
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
         self.clear_items()
         self.add_menu()
         self.add_buttons()

--- a/rolemanager/core/views.py
+++ b/rolemanager/core/views.py
@@ -324,7 +324,7 @@ class ReactionRoleCreationPanel(RoleManagerView):
             },
             "emoji": {
                 "label": "Emoji",
-                "required": False,
+                "required": self.trigger_type == TriggerType.REACTION,
                 "max_length": _short_length,
             },
         }
@@ -421,7 +421,7 @@ class ReactionRoleCreationPanel(RoleManagerView):
             "role": AssignableRole,
         }
         errors = []
-        if self.current_input["emoji"] is None and self.current_input["label"] is None:
+        if self.current_input["emoji"] is None and self.current_input.get("label") is None:
             errors.append("ValueError: Emoji and Label cannot both be None.")
 
         ret = {}

--- a/rolemanager/info.json
+++ b/rolemanager/info.json
@@ -10,7 +10,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "1.1.6",
+    "version": "2.0.0",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/rolemanager/rolemanager.py
+++ b/rolemanager/rolemanager.py
@@ -104,7 +104,7 @@ _rule_session = (
 _bind_session = (
     "Choose a color for the button using the dropdown menu below. If not selected, defaults to Blurple.\n\n"
     "__**Buttons:**__\n"
-    "- `Edit` to  set or edit the current set values.\n"
+    "- `Set` to  set or edit the current set values.\n"
     "- `Add` to bind a role to a button. This button only available if there were **no errors** when the values were submitted.\n"
     "- `Clear` to reset all binds.\n\n"
     "__**Available fields:**__\n"
@@ -988,7 +988,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
             title=title,
             color=self.bot.main_color,
         )
-        view.placeholder_description = "Press the following buttons to receive the corresponding roles:\n"
+        view.placeholder_description = "Press the following buttons to receive the corresponding roles:\n\n"
 
         embed = discord.Embed(
             title="Reaction Roles Creation",

--- a/rolemanager/rolemanager.py
+++ b/rolemanager/rolemanager.py
@@ -204,7 +204,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.MODERATOR)
     async def role_members(self, ctx: commands.Context, *, role: discord.Role):
         """
-        Sends a list of members in a role.
+        Show a list of members in a role.
 
         `role` may be a role ID, mention, or name.
         """
@@ -254,7 +254,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.MODERATOR)
     async def role_colors(self, ctx: commands.Context):
         """
-        Sends the server's roles, ordered by color.
+        Show a list of server's roles, ordered by color.
         """
         roles = defaultdict(list)
         for r in ctx.guild.roles:
@@ -277,7 +277,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         return await session.run()
 
     @role_.command(name="create")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_create(
         self,
         ctx: commands.Context,
@@ -287,7 +287,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         name: str = None,
     ):
         """
-        Creates a role.
+        Create a role.
 
         Color and whether it is hoisted can be specified.
 
@@ -383,7 +383,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await ctx.send(f"Removed **{role.name}** from **{member}**.")
 
     @role_.command(require_var_positional=True)
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def addmulti(self, ctx: commands.Context, role: AssignableRole, *members: discord.Member):
         """
         Add a role to multiple members.
@@ -412,7 +412,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await ctx.send("\n".join(msg))
 
     @role_.command(require_var_positional=True)
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def removemulti(self, ctx: commands.Context, role: AssignableRole, *members: discord.Member):
         """
         Remove a role from multiple members.
@@ -519,7 +519,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await ctx.send("\n".join(msg))
 
     @role_.command(name="all")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_all(self, ctx: commands.Context, *, role: AssignableRole):
         """
         Add a role to all members of the server.
@@ -529,7 +529,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await self.super_massrole(ctx, ctx.guild.members, role)
 
     @role_.command(name="rall", aliases=["removeall"])
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_rall(self, ctx: commands.Context, *, role: AssignableRole):
         """
         Remove a role from all members of the server.
@@ -540,7 +540,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await self.super_massrole(ctx, member_list, role, "No one on the server has this role.", False)
 
     @role_.command(name="humans")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_humans(self, ctx: commands.Context, *, role: AssignableRole):
         """
         Add a role to all humans (non-bots) in the server.
@@ -555,7 +555,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         )
 
     @role_.command(name="rhumans")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_rhumans(self, ctx: commands.Context, *, role: AssignableRole):
         """
         Remove a role from all humans (non-bots) in the server.
@@ -571,7 +571,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         )
 
     @role_.command(name="bots")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_bots(self, ctx: commands.Context, *, role: AssignableRole):
         """
         Add a role to all bots in the server.
@@ -586,7 +586,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         )
 
     @role_.command(name="rbots")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_rbots(self, ctx: commands.Context, *, role: AssignableRole):
         """
         Remove a role from all bots in the server.
@@ -602,7 +602,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         )
 
     @role_.command(name="in")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_in(
         self,
         ctx: commands.Context,
@@ -623,7 +623,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         )
 
     @role_.command(name="rin")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_rin(
         self,
         ctx: commands.Context,
@@ -645,7 +645,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         )
 
     @role_.group(name="target", invoke_without_command=True)
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def role_target(self, ctx: commands.Context):
         """
         Modify roles using 'targeting' args.
@@ -655,7 +655,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await ctx.send_help(ctx.command)
 
     @role_target.command(name="add")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def target_add(self, ctx: commands.Context, role: AssignableRole, *, args: str):
         """
         Add a role to members using targeting args.
@@ -673,7 +673,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         )
 
     @role_target.command(name="remove")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def target_remove(self, ctx: commands.Context, role: AssignableRole, *, args: str):
         """
         Remove a role from members using targeting args.
@@ -929,7 +929,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await ctx.send_help(ctx.command)
 
     @reactrole.command(name="enable")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def reactrole_enable(self, ctx: commands.Context, mode: bool = None):
         """
         Toggle reaction roles on or off.
@@ -974,6 +974,10 @@ class RoleManager(commands.Cog, name=__plugin_name__):
 
         `channel` if specified, may be a channel ID, mention, or name.
         If not specified, will be the channel where the command is ran from.
+        `title` is the title for the embed. Must not exceed 256 characters.
+
+        __**Notes:**__
+        - This command will instantiate the button and text input interactive session.
         """
         done_session = "The reaction roles {} has been posted."  # format hyperlink message.jump_url
         input_sessions = [
@@ -1015,15 +1019,16 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await self.config.update()
 
     @reactrole.command(name="add", aliases=["bind", "link"])
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def reactrole_add(self, ctx: commands.Context, message: discord.Message):
         """
-        Bind a reaction role to a button on a message that already exists.
+        Add role-button binds to a message that already exists.
+        This can be used if you want to create a reaction roles menu on a pre-existing message.
 
         `message` may be a message ID or message link.
 
         __**Notes:**__
-        - This can be used if you want to create a reaction roles menu on a pre-existing message.
+        - This command will instantiate the button and text input interactive session.
         """
         new = False
         reactrole = self.config.reactroles.find_entry(message.id)
@@ -1062,7 +1067,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await self.config.update()
 
     @reactrole.command(name="rule")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def reactrole_rule(
         self,
         ctx: commands.Context,
@@ -1112,14 +1117,14 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         )
 
     @reactrole.group(name="delete", aliases=["remove"], invoke_without_command=True)
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def reactrole_delete(
         self,
         ctx: commands.Context,
         message: Union[discord.Message, ObjectConverter, int],
     ):
         """
-        Delete entire reaction role buttons from a message.
+        Delete entire reaction roles buttons from a message.
 
         `message` may be a message ID or message link.
         """
@@ -1151,7 +1156,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await ctx.send(embed=self.base_embed("Reaction roles cleared for that message."))
 
     @reactrole_delete.command(name="bind", aliases=["link"])
-    @checks.has_permissions(PermissionLevel.MODERATOR)
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def delete_bind(
         self,
         ctx: commands.Context,
@@ -1273,7 +1278,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.OWNER)
     async def reactrole_repair(self, ctx: commands.Context):
         """
-        Repair unresolved Reaction Roles data.
+        Repair unresolved reaction roles data.
 
         __**Notes:**__
         - Usually the data cannot be resolved due to the bot is missing permissions, or the message or channel was deleted.
@@ -1296,10 +1301,10 @@ class RoleManager(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.OWNER)
     async def reactrole_clear(self, ctx: commands.Context):
         """
-        Clear all Reaction Role data.
+        Clear all reaction roles data.
         This will wipe all reaction roles data from the database, and the buttons attached to the messages will be removed.
 
-        This operation cannot be undone.
+        This operation **cannot** be undone.
         """
         view = ConfirmView(bot=self.bot, user=ctx.author)
         view.message = await ctx.send(

--- a/rolemanager/rolemanager.py
+++ b/rolemanager/rolemanager.py
@@ -1229,7 +1229,9 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         if reactrole.view:
             await reactrole.view.update_view()
         await self.config.update()
-        await ctx.send(embed=self.base_embed("That role bind to a button or emoji on that message is now deleted."))
+        await ctx.send(
+            embed=self.base_embed("That role bind to a button or emoji on that message is now deleted.")
+        )
 
     @reactrole.command(name="list")
     @checks.has_permissions(PermissionLevel.MODERATOR)

--- a/rolemanager/rolemanager.py
+++ b/rolemanager/rolemanager.py
@@ -111,13 +111,13 @@ _rule_session = (
 _bind_session = (
     "Choose a color for the button using the dropdown menu below. If not selected, defaults to Blurple.\n\n"
     "__**Buttons:**__\n"
-    "- `Add` to bind a role to a button or emoji. This button only available if there were **no errors** when the values were submitted.\n"
-    "- `Set` to  set or edit the current set values.\n"
-    "- `Clear` to reset all binds.\n\n"
+    "- **Add** - Add a role-button or role-emoji bind to internal list. This only available if there were **no errors** when the values were submitted.\n"
+    "- **Set** - Set or edit the current set values.\n"
+    "- **Clear** - Reset all binds.\n\n"
     "__**Available fields:**__\n"
-    "- **Role** - The role to bind to the emoji or button. May be a role ID, name, or format of `<@&roleid>`.\n"
-    "- **Emoji** - Emoji to bind (reaction), or shown on the button (interaction). May be a unicode emoji, format of `:name:`, `<name:id>` or `<a:name:id>` (animated emoji).\n"
-    "- **Label** - Button label (only available for button). Must not exceed 80 characters.\n"
+    "- `Role` - The role to bind to the emoji or button. May be a role ID, name, or format of `<@&roleid>`.\n"
+    "- `Emoji` - Emoji to bind (reaction), or shown on the button (interaction). May be a unicode emoji, format of `:name:`, `<name:id>` or `<a:name:id>` (animated emoji).\n"
+    "- `Label` - Button label (only available for button). Must not exceed 80 characters.\n"
 )
 
 
@@ -931,7 +931,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.MODERATOR)
     async def reactrole(self, ctx: commands.Context):
         """
-        Base command for Reaction Role management.
+        Base command for Reaction Roles management.
         """
         await ctx.send_help(ctx.command)
 
@@ -977,7 +977,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         title: str = None,
     ):
         """
-        Create a new reaction role menu.
+        Create a new reaction roles menu.
 
         `channel` if specified, may be a channel ID, mention, or name.
         If not specified, will be the channel where the command is ran from.
@@ -1035,17 +1035,18 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         await view.message.edit(embed=embed, view=view)
         await self.config.update()
 
-    @reactrole.command(name="edit")
+    @reactrole.command(name="edit", aliases=["add"])
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def reactrole_edit(self, ctx: commands.Context, message: discord.Message):
         """
-        Edit by adding role-button or role-emoji binds to a message that already exists.
+        Edit by adding role-button or role-emoji binds to a message specified.
         This can be used if you want to create a reaction roles menu on a pre-existing message.
 
         `message` may be a message ID, message link, or format of `channelid-messageid`.
 
         __**Notes:**__
         - This command will initiate the button and text input interactive session.
+        - Buttons can only be added on messages that were sent from this bot.
         """
         new = False
         reactrole = self.config.reactroles.find_entry(message.id)
@@ -1115,7 +1116,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         rules: str.upper = None,
     ):
         """
-        Set rule for an existing reaction role message.
+        Set a rule for an existing reaction roles message.
 
         `message` may be a message ID, message link, or format of `channelid-messageid`.
 
@@ -1164,7 +1165,8 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         message: Union[discord.Message, ObjectConverter, int],
     ):
         """
-        Delete entire reaction roles buttons from a message.
+        Delete reaction roles data from a message.
+        If the set trigger type is `Interaction` (i.e. buttons), the buttons will be cleared from the message.
 
         `message` may be a message ID, message link, or format of `channelid-messageid`.
         """
@@ -1278,8 +1280,9 @@ class RoleManager(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.OWNER)
     async def reactrole_refresh(self, ctx: commands.Context):
         """
-        Refresh buttons on all reaction roles messages.
-        This will remove buttons with broken data from the reaction roles messages.
+        Refresh all reaction roles data.
+        This will look for non-existing linked roles and remove the necessary binds linked to the roles.
+        This will also remove buttons with broken data from the reaction roles messages.
 
         __**Notes:**__
         - The reaction roles binds are considered broken if they are linked to deleted roles.
@@ -1316,7 +1319,7 @@ class RoleManager(commands.Cog, name=__plugin_name__):
                 n += 1
             await self.config.update()
         else:
-            output = "No broken components."
+            output = "No broken data or components."
         embed.description = output
         await ctx.send(embed=embed)
 

--- a/rolemanager/rolemanager.py
+++ b/rolemanager/rolemanager.py
@@ -1224,11 +1224,12 @@ class RoleManager(commands.Cog, name=__plugin_name__):
             del reactrole.binds[str(role.id)]
         except KeyError:
             raise commands.BadArgument(
-                f"Role {role.mention} is not binded to any button on the message specified."
+                f"Role {role.mention} is not binded to any button or emoji on that message."
             )
-        await reactrole.view.update_view()
+        if reactrole.view:
+            await reactrole.view.update_view()
         await self.config.update()
-        await ctx.send(embed=self.base_embed("That role-button bind was deleted."))
+        await ctx.send(embed=self.base_embed("That role bind to a button or emoji on that message is now deleted."))
 
     @reactrole.command(name="list")
     @checks.has_permissions(PermissionLevel.MODERATOR)
@@ -1246,10 +1247,11 @@ class RoleManager(commands.Cog, name=__plugin_name__):
         for index, entry in enumerate(entries, start=1):
             message = entry.message
             rules = entry.rules
-            output = [f"[Reaction Role #{index}]({message.jump_url}) - `{rules}`"]
-            for role_id, button in entry.binds.items():
-                emoji = button.get("emoji")
-                identifier = f"{emoji} " if emoji else "" + button.get("label", "")
+            trigger_type = entry.trigger_type
+            output = [f"[Reaction Role #{index}]({message.jump_url}) - `{trigger_type}`, `{rules}`"]
+            for role_id, payload in entry.binds.items():
+                emoji = payload.get("emoji")
+                identifier = f"{emoji} " if emoji else "" + payload.get("label", "")
                 output.append(f"**{identifier}** : <@&{role_id}>")
             if len(output) > 1:
                 react_roles.append("\n".join(output))


### PR DESCRIPTION
__**UPDATE:**__
- Support reaction roles with buttons.
- Reaction roles creation uses buttons and text inputs.
- Adding role-button or role-emoji binds to a message. This allows server Administrator to manually add role-button or role-emoji binds to existing **bot's** messages.
- Update commands permission level. Only allow `ADMINISTRATOR` level users to use heavy or risky commands.
- Other QOL improvements.

__**BREAKING:**__

- ~~Old reaction roles data will be wiped (currently looking for a way to solve this) since the data order in the database will change.~~

__**LIMITATIONS:**__
- Buttons can only be added on the bot's messages.
- On a single message:
       - 5 buttons per row.
       - Can only have 5 rows.
 So 25 buttons per message.