### PR TITLE
`moderation` plugin v1.3.1

### DIFF
--- a/moderation/core/config.py
+++ b/moderation/core/config.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = {
     "log_channel": str(int()),
     "logging": False,
     "webhook": None,
+    "channel_whitelist": [],
 }
 
 

--- a/moderation/core/logging.py
+++ b/moderation/core/logging.py
@@ -5,7 +5,6 @@ import io
 from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
 import discord
-from discord.utils import MISSING
 from discord.ext.modmail_utils import plural
 
 from core.models import getLogger
@@ -130,7 +129,7 @@ class ModerationLogging:
                 embed.set_footer(text=f"Channel ID: {target.id}")
             else:
                 raise TypeError(
-                    f"Invalid type of target. Expected Member, User, GuildChannel, List, or None. Got {type(taget).__name__} instead."
+                    f"Invalid type of target. Expected Member, User, GuildChannel, List, or None. Got {type(target).__name__} instead."
                 )
 
         if reason is not None:
@@ -237,6 +236,7 @@ class ModerationLogging:
             after.guild,
             action="avatar update",
             target=after,
+            description=description,
         )
 
     async def _on_member_nick_update(
@@ -524,11 +524,11 @@ class ModerationLogging:
 
         messages = sorted(payload.cached_messages, key=lambda msg: msg.created_at)
         message_ids = payload.message_ids
-        upload_text = f"Deleted messages:\n\n"
+        upload_text = "Deleted messages:\n\n"
 
         if not messages:
             upload_text += "There are no known messages.\n"
-            upload_text += f"Message IDs: " + ", ".join(map(str, message_ids)) + "."
+            upload_text += "Message IDs: " + ", ".join(map(str, message_ids)) + "."
         else:
             known_message_ids = set()
             for message in messages:
@@ -543,7 +543,7 @@ class ModerationLogging:
                 )
             unknown_message_ids = message_ids ^ known_message_ids
             if unknown_message_ids:
-                upload_text += f"Unknown message IDs: " + ", ".join(map(str, unknown_message_ids)) + "."
+                upload_text += "Unknown message IDs: " + ", ".join(map(str, unknown_message_ids)) + "."
 
         action = "bulk message deleted"
         embed = discord.Embed(

--- a/moderation/info.json
+++ b/moderation/info.json
@@ -6,7 +6,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/moderation/moderation.py
+++ b/moderation/moderation.py
@@ -14,7 +14,6 @@ from typing import (
     Dict,
     Optional,
     Union,
-    List,
     TYPE_CHECKING,
 )
 

--- a/moderation/moderation.py
+++ b/moderation/moderation.py
@@ -1522,6 +1522,18 @@ class Moderation(commands.Cog):
     async def on_guild_channel_delete(self, *args, **kwargs) -> None:
         await self.logging.on_guild_channel_delete(*args, **kwargs)
 
+    @commands.Cog.listener()
+    async def on_raw_message_delete(self, *args, **kwargs) -> None:
+        await self.logging.on_raw_message_delete(*args, **kwargs)
+
+    @commands.Cog.listener()
+    async def on_raw_bulk_message_delete(self, *args, **kwargs) -> None:
+        await self.logging.on_raw_bulk_message_delete(*args, **kwargs)
+
+    @commands.Cog.listener()
+    async def on_raw_message_edit(self, *args, **kwargs) -> None:
+        await self.logging.on_raw_message_edit(*args, **kwargs)
+
 
 async def setup(bot: ModmailBot) -> None:
     await bot.add_cog(Moderation(bot))


### PR DESCRIPTION
This PR adds support for logging message events (edit and delete).

Group command `?logging config whitelist` is added. This is to make sure message update events in the whitelisted channels (or category) will always be ignored. Its subcommands are:
- `add`
- `remove`
- `clear`
- `list`