### PR TITLE
`supportutils` plugin v0.4.0:

### DIFF
--- a/supportutils/core/views.py
+++ b/supportutils/core/views.py
@@ -151,7 +151,7 @@ class ContactView(BaseView):
             "emoji": emoji,
             "label": label,
             "style": style,
-            "custom_id": f"contact_button:{self.message.channel.id}-{self.message.id}",
+            "custom_id": f"contact_button",
             "callback": self.handle_interaction,
         }
         self.add_item(Button(**payload))

--- a/supportutils/core/views.py
+++ b/supportutils/core/views.py
@@ -195,7 +195,7 @@ class ContactView(BaseView):
         await interaction.response.defer()
         view = select.view
         view.inputs["contact_dropdown"] = option
-        view.disable_and_stop()
+        view.stop()
         await view.message.delete()
 
     async def handle_interaction(self, interaction: Interaction, button: Button) -> None:
@@ -359,8 +359,8 @@ class FeedbackView(BaseView):
         select: DropdownMenu,
         option: discord.SelectOption,
     ) -> None:
-        await interaction.response.defer()
         self._rating = option
+        await interaction.response.edit_message(view=select.view)
 
     async def _button_callback(self, *args, **kwargs) -> None:
         """

--- a/supportutils/info.json
+++ b/supportutils/info.json
@@ -8,7 +8,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/supportutils/info.json
+++ b/supportutils/info.json
@@ -8,7 +8,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "0.3.6",
+    "version": "0.4.0",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -92,14 +92,8 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
             prefix, session = args
 
         valid_sessions = ("button", "dropdown", "embed")
-        if session not in valid_sessions:
-            raise ValueError(
-                f"Invalid view input session. Expected {human_join(valid_sessions)}, "
-                f"got `{session}` instead."
-            )
-
         options = {}
-        if session == "button":
+        if session == valid_sessions[0]:
             elements = [("emoji", 256), ("label", Limit.button_label), ("style", 32)]
             button_config = getattr(self.config, prefix, {}).get("button")
             for elem in elements:
@@ -109,7 +103,21 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
                     "required": False,
                     "default": view.inputs.get(elem[0]) or button_config.get(elem[0]),
                 }
-        elif session == "embed":
+        elif session == valid_sessions[1]:
+            elements = [
+                ("emoji", 256),
+                ("label", Limit.button_label),
+                ("description", Limit.select_description),
+                ("category", 256),
+            ]
+            for elem in elements:
+                options[elem[0]] = {
+                    "label": elem[0].title(),
+                    "max_length": elem[1],
+                    "required": elem[0] in ("label", "category"),
+                    "default": view.inputs.get(elem[0]),
+                }
+        elif session == valid_sessions[2]:
             elements = [
                 ("title", Limit.embed_title),
                 ("description", Limit.text_input_max),
@@ -125,19 +133,10 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
                     "default": view.inputs.get(elem[0]) or embed_config.get(elem[0]),
                 }
         else:
-            elements = [
-                ("emoji", 256),
-                ("label", Limit.button_label),
-                ("description", Limit.select_description),
-                ("category", 256),
-            ]
-            for elem in elements:
-                options[elem[0]] = {
-                    "label": elem[0].title(),
-                    "max_length": elem[1],
-                    "required": elem[0] in ("label", "category"),
-                    "default": view.inputs.get(elem[0]),
-                }
+            raise ValueError(
+                f"Invalid view input session. Expected {human_join(valid_sessions)}, "
+                f"got `{session}` instead."
+            )
         return options
 
     async def _button_callback(self, interaction: discord.Interaction, item: Button) -> None:

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -297,9 +297,8 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
             footer_text = f"{self.bot.guild.name}: Contact menu"
         embed.set_footer(text=footer_text, icon_url=self.bot.guild.icon)
 
-        manager.message = message = await channel.send(embed=embed)
-        view = ContactView(self, message)
-        await message.edit(view=view)
+        view = ContactView(self)
+        manager.message = view.message = await channel.send(embed=embed, view=view)
         self.config.contact["message"] = str(message.id)
         self.config.contact["channel"] = str(message.channel.id)
         await self.config.update()

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -255,7 +255,12 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
     async def cm_create(self, ctx: commands.Context, *, channel: Optional[discord.TextChannel] = None):
         """
         Create a contact message and add contact components to it.
-        Button and dropdown settings will be retrieved from config.
+        Button and dropdown settings will be retrieved from config. If you want to have custom settings, make sure to set those first with:
+        - `{prefix}contactmenu config [option] [value]`
+        Otherwise default settings will be used.
+
+        Or you can customise the settings later, then to apply new settings use command:
+        - `{prefix}contactmenu refresh`
 
         `channel` if specified, may be a channel ID, mention, or name.
         If not specified, fallbacks to current channel.
@@ -286,7 +291,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
             footer_text = f"{self.bot.guild.name}: Contact menu"
         embed.set_footer(text=footer_text, icon_url=self.bot.guild.icon)
 
-        message = await channel.send(embed=embed)
+        manager.message = message = await channel.send(embed=embed)
         view = ContactView(self, message)
         await message.edit(view=view)
         self.config.contact["message"] = str(message.id)
@@ -300,7 +305,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def cm_attach(self, ctx: commands.Context, *, message: discord.Message):
         """
-        Attach the contact components to the message specified.
+        Attach contact components to the message specified.
         Button and dropdown settings will be retrieved from config.
 
         `message` may be a message ID, link, or format of `channelid-messageid`.
@@ -351,7 +356,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def cm_disable(self, ctx: commands.Context):
         """
-        Clear the contact components attached to the contact menu message.
+        Clear contact components attached to the contact menu message.
         This will remove the button and dropdown, and stop listening to interactions made on the message.
         """
         manager = self.contact_manager
@@ -403,7 +408,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         embed = discord.Embed(
             title="Contact embed",
             color=self.bot.main_color,
-            description=ctx.command.help,
+            description=ctx.command.help.format(prefix=self.bot.prefix),
         )
         embed.set_footer(text="Press Set to set/edit the values")
         embed_config = self.config.contact.get("embed")

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -208,9 +208,6 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
                 errors.append(f"{type(exc).__name__}: {str(exc)}")
                 continue
             if isinstance(entity, discord.CategoryChannel):
-                if entity == self.bot.main_category:
-                    errors.append("ValueError: Category must be different than the main category.")
-                    continue
                 # check exists
                 for data in self.config.contact["select"]["options"]:
                     category_id = data["category"]
@@ -259,7 +256,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         - `{prefix}contactmenu config [option] [value]`
         Otherwise default settings will be used.
 
-        Or you can customise the settings later, then to apply new settings use command:
+        Or you can customise the settings later, then apply the new settings with command:
         - `{prefix}contactmenu refresh`
 
         `channel` if specified, may be a channel ID, mention, or name.
@@ -594,13 +591,14 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         help=(
             "Add and customize the dropdown for contact menu.\n\n"
             "A select option can be linked to a custom category where the thread will be created.\n\n"
-            "__**Available options:**__\n"
+            "__**Available fields:**__\n"
             "- **Emoji** : Emoji for select option. May be a unicode emoji, format of `:name:`, `<:name:id>` "
             "or `<a:name:id>` (animated emoji).\n"
-            f"- **Label** : Label for select option. Must be {Limit.select_label} or fewer in length.\n"
+            f"- **Label** : Label for select option. Must be {Limit.select_label} or fewer in length. "
+            "This field is required.\n"
             f"- **Description** : Short description for the option. Must not exceed {Limit.select_description} characters.\n"
             "- **Category** : The discord category channel where the thread will be created if the user choose the option. "
-            "This field is required and the value must be different than the `main category`.\n"
+            "This field is required.\n"
         ),
     )
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -255,7 +255,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         - `{prefix}contactmenu config [option] [value]`
         Otherwise default settings will be used.
 
-        Or you can customise the settings later, then apply the new settings with command:
+        Or you can customize the settings later, then apply the new settings with command:
         - `{prefix}contactmenu refresh`
 
         `channel` if specified, may be a channel ID, mention, or name.


### PR DESCRIPTION
- Fix bug in `contactmenu refresh` command due to `.message` attribute was not properly set to `ContactManager` when creating contact menu.
- Remove dropdown from contact menu message. Instead the dropdown will only appear after the contact button is pressed.
- Reduce API calls when posting `ContactView` and `FeedbackView`. The `message` parameter is no longer required. We also remove the need of `message.id` in component's `custom_id`.
- `contactmenu config dropdown placeholder` command now also uses buttons and modal view to set the value.
- Update help docs.