### PR TITLE
`utils` plugin v1.2.2

### DIFF
--- a/utils/discord/ext/modmail_utils/config.py
+++ b/utils/discord/ext/modmail_utils/config.py
@@ -150,11 +150,18 @@ class Config(BaseConfig):
             f"<{self.__class__.__name__} cog='{self.cog.qualified_name}' id='{self._id}' cache={self._cache}>"
         )
 
-    async def fetch(self) -> DataT:
+    async def fetch(self, *, resolve_default_keys: bool = True) -> DataT:
         """
         Fetches the data from database. If the response data is `None` default data will be returned.
 
         By default if cache is enabled, this will automatically refresh the cache after the data is retrieved.
+
+        Parameters
+        -----------
+        resolve_default_keys : bool
+            Check if all default keys exist in the fetched data. If any key does not exist,
+            the default and its value will be set. For this to work, a dictionary for `.defaults` attribute
+            must be set. Defaults to `True`.
 
         Returns
         -------
@@ -168,6 +175,12 @@ class Config(BaseConfig):
             else:
                 # empty dict to resolve AttributeError in `.refresh`
                 data = {}
+
+        if self.defaults is not None and resolve_default_keys:
+            for key, value in self.defaults.items():
+                if key not in data:
+                    data[key] = self.deepcopy(value)
+
         if self.cache_enabled():
             self.refresh(data=data)
         return data

--- a/utils/discord/ext/modmail_utils/ui.py
+++ b/utils/discord/ext/modmail_utils/ui.py
@@ -179,9 +179,10 @@ class View(ui.View):
         """
         pass
 
-    async def update_message(self, *, view: View = MISSING, **kwargs) -> None:
+    async def edit_message(self, *, view: View = MISSING, **kwargs) -> None:
         """
-        Update this View's current state on a message.
+        Edit the message assigned for this view.
+        View's current state will be updated as well.
 
         This will only work if the `.message` attribute is set.
         Additonal keyword arguments can also be passed.
@@ -222,7 +223,6 @@ class View(ui.View):
         """
         Called on View's timeout. This will disable all components and update the message.
         """
-        self.disable_all()
-        self._stop_modals()
+        self.disable_and_stop()
         if self.message:
-            await self.update_message()
+            await self.edit_message()

--- a/utils/discord/ext/modmail_utils/views.py
+++ b/utils/discord/ext/modmail_utils/views.py
@@ -49,6 +49,9 @@ class ConfirmView(View):
         The author that triggered this confirmation view.
     timeout : float
         Time before this view timed out. Defaults to `20` seconds.
+    delete : bool
+        Whether to delete the message after timeout or successful interaction
+        has been made. For cleaner output, this defaults to `True`.
     """
 
     children: List[discord.ui.Button]
@@ -57,14 +60,19 @@ class ConfirmView(View):
         self,
         bot: ModmailBot,
         user: Union[discord.Member, discord.User],
+        *,
         timeout: float = 20.0,
+        delete: bool = True,
     ):
         self.bot: ModmailBot = bot
         self.user: Union[discord.Member, discord.User] = user
+        self._delete_when_complete: bool = delete
         super().__init__(timeout=timeout)
         self._selected_button: discord.ui.Button = MISSING
 
     async def interaction_check(self, interaction: Interaction) -> bool:
+        if self.message is MISSING:
+            self.message = interaction.message
         if self.user.id == interaction.user.id:
             return True
         await interaction.response.send_message("These buttons cannot be controlled by you.", ephemeral=True)
@@ -90,16 +98,16 @@ class ConfirmView(View):
         self.value = False
         await self.conclude(interaction)
 
-    async def conclude(self, interaction: Interaction):
+    async def conclude(self, interaction: Interaction) -> None:
         """
         Finalize and stop the view after interaction is made.
 
         Depends on the `.message` attribute, if it is ephemeral the message will be deleted.
         Otherwise it will be updated with all buttons disabled.
         """
-        if self.message.flags.ephemeral:
+        if self.message.flags.ephemeral or self._delete_when_complete:
             await interaction.response.defer()
-            await self.message.delete()
+            await interaction.delete_original_response()
         else:
             self.refresh()
             await interaction.response.edit_message(view=self)
@@ -107,16 +115,21 @@ class ConfirmView(View):
 
     def refresh(self) -> None:
         """
-        Disables the buttons on the view. Unselected button will be greyed out.
+        Refresh the buttons on this view. If interaction has been made the buttons
+        will be disabled.
+        Unselected button will be greyed out.
         """
         for child in self.children:
-            child.disabled = True
+            child.disabled = self.value is not None
             if self._selected_button and child != self._selected_button:
-                child.style = ButtonStyle.grey
+                child.style = discord.ButtonStyle.grey
 
     async def on_timeout(self) -> None:
-        if self.message.flags.ephemeral:
+        self.stop()
+        if not self.message:
+            return
+        if self._delete_when_complete:
             await self.message.delete()
         else:
             self.refresh()
-            await self.message.edit(view=view)
+            await self.message.edit(view=self)

--- a/utils/info.json
+++ b/utils/info.json
@@ -5,7 +5,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "requirements": []

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -214,8 +214,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
                     getattr(extension, "__cogs_required__", None)
                     or extension.__plugin_info__["cogs_required"]
                 )
-            except (AttributeError, KeyError) as exc:
-                logger.error(f"{type(exc).__name__}: {str(exc)}", exc_info=True)
+            except (AttributeError, KeyError):
                 continue
 
             if self.qualified_name not in cogs_required:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -90,7 +90,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
 
     async def install_packages(self) -> None:
         """
-        Install additional packages. Currently we only use `modmail-utils` custom package.
+        Currently we only use `modmail-utils` custom package.
         This method was adapted from cogs/plugins.py.
         """
         req = self.package_path
@@ -130,7 +130,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
             text = f.read()
         return re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', text, re.MULTILINE).group(1)
 
-    @commands.group(name="ext-utils", invoke_without_command=True)
+    @commands.group(name="ext-utils", aliases=["eutils"], invoke_without_command=True)
     @checks.has_permissions(PermissionLevel.OWNER)
     async def ext_utils(self, ctx: commands.Context):
         """
@@ -195,13 +195,18 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
     async def utils_reorder(self, ctx: commands.Context):
         """
         Reorder the plugins loading order.
-        Generally no need to run this command, but put here just in case.
+        Generally there is no need to run this command, but it is put here just in case.
         This is just to make sure the plugins that require this plugin will load last or after this plugin is loaded.
         """
         plugins_cog = self.bot.get_cog("Plugins")
         ordered = []
+        utils_pos = False
         for plugin in plugins_cog.loaded_plugins:
+            if plugin.name == "utils":
+                utils_pos = True
+                continue
             try:
+
                 extension = self.bot.extensions[plugin.ext_string]
                 if not hasattr(extension, "__plugin_info__"):
                     continue
@@ -209,13 +214,14 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
                     getattr(extension, "__cogs_required__", None)
                     or extension.__plugin_info__["cogs_required"]
                 )
-            except (AttributeError, KeyError):
+            except (AttributeError, KeyError) as exc:
+                logger.error(f"{type(exc).__name__}: {str(exc)}", exc_info=True)
                 continue
 
             if self.qualified_name not in cogs_required:
                 continue
 
-            if str(plugin) in self.bot.config["plugins"]:
+            if not utils_pos and str(plugin) in self.bot.config["plugins"]:
                 # just remove and append it back
                 self.bot.config["plugins"].remove(str(plugin))
                 self.bot.config["plugins"].append(str(plugin))
@@ -224,12 +230,14 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
         embed = discord.Embed(color=self.bot.main_color)
         if ordered:
             await self.bot.config.update()
-            description = "Reordered the plugins.\n"
-            description += "```\n"
-            description += "\n".join(ordered)
-            description += "\n```"
+            description = "__**Reordered:**__\n"
+            description += "```\n" + "\n".join(ordered) + "\n```"
+            description += (
+                "\n\n__**Note:**__\nYou may need to restart the bot to reload the reordered plugins."
+            )
         else:
-            description = "Nothing changed."
+            embed.color = self.bot.error_color
+            description = "The plugins are already properly ordered."
         embed.description = description
         await ctx.send(embed=embed)
 


### PR DESCRIPTION
### Changelog
- Update `ConfirmView`:
  - By default, confirmation message will be deleted after the view is done whether with successful interaction or timeout.
  - Add `delete` parameter. This is to specify whether to delete the message after the view is done. For cleaner output, this defaults to `True`.
  - Update `on_timeout`. Message will be edited or deleted if `.message` attribute is assigned. There were cases where the `.message` attribute cannot be assigned directly (without additional API call). So in this case you may want to set a value for `delete_after` parameter when sending the message. Example:
```py
view = ConfirmView(self.bot, interaction.user)
await interaction.response.send_message("Hello", ephemeral=True, delete_after=view.timeout)
```

- Update `Config`:
  - Add `resolve_default_keys` parameter in `.fetch()`. This is to prevent `KeyError` due to some of the keys were not saved into the database. Happened in `supportutils` plugin before the temporary solution were made.

- Add alias `eutils` for `ext-utils` command.

- Update `ext-utils reorder` command:
  - Now the plugins that match the criteria will only be reordered if they were loaded before `utils` plugin.
  - Update response description.