### PR TITLE
`supportutils` plugin v0.4.4

### DIFF
--- a/supportutils/core/models.py
+++ b/supportutils/core/models.py
@@ -96,7 +96,7 @@ class ContactManager:
                 color=self.bot.error_color,
                 description="Something went wrong. A thread for you already exists.",
             )
-            await interaction.followup.send(embed=embed, ephemeral=True, delete_after=10)
+            await interaction.followup.send(embed=embed, ephemeral=True)
             return
 
         thread = Thread(self.bot.threads, recipient)

--- a/supportutils/info.json
+++ b/supportutils/info.json
@@ -8,7 +8,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]


### PR DESCRIPTION
### Changelog
**Fix potential ratelimits issue:**
- As [`Interaction.followup`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#discord.Interaction.followup) uses global ratelimits and not per interaction, we have changed it to use [`Interaction.response`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#discord.Interaction.response) instead.
- Add `._temp_cached_users` attribute to `ContactView`. This is to prevent unecessary repeated responses when same user spamming the button.
 
**Others:**
- No longer deal with `Thread.wait_until_ready()` since we already sent the confirmation before starting to create thread anyways. So now we just check if the thread exists. If exists, we just send error response and return.
- Fix `UnknownInteraction` error when check fails. To reproduce (in order):
  - Create contact menu (if there isn't one)
  - `confirm_thread_creation` set to `True`
  - DM the bot, leave the confirmation message untouched
  - Press the Contact button on the contact message
- Rename `ContactManager.create` to `.create_thread`.
- Other minor code improvements.