### PR TITLE
`utils` plugin v1.3.0

### DIFF
--- a/utils/core/config.py
+++ b/utils/core/config.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
     from ..utils import ExtendedUtils
 
 
+__all__ = ("UtilsConfig",)
+
+
 logger = getLogger(__name__)
 
 
@@ -41,10 +44,20 @@ _optional = {
     "confirm_button_deny_emoji",
 }
 
+_config_descriptions = {
+    "confirm_button_accept_label": "Label for accept confirmation button.",
+    "confirm_button_accept_emoji": "Emoji for accept confirmation button.",
+    "confirm_button_accept_style": "Button color style. The only available options are as follows:\n\t-`1` - Blurple\n\t-`2` - Grey\n\t-`3` - Green\n\t-`4` - Red",
+    "confirm_button_deny_label": "Label for deny confirmation button.",
+    "confirm_button_deny_emoji": "Emoji for accept confirmation button.",
+    "confirm_button_deny_style": "Button color style. The only available options are as follows:\n\t-`1` - Blurple\n\t-`2` - Grey\n\t-`3` - Green\n\t-`4` - Red",
+}
+
 
 class UtilsConfig(Config):
     def __init__(self, cog: ExtendedUtils, db: AsyncIOMotorCollection):
         super().__init__(cog, db, defaults=_default_config)
+        self.config_descriptions: Dict[str, str] = _config_descriptions
 
     def set(self, key: str, item: Any) -> None:
         """

--- a/utils/core/config.py
+++ b/utils/core/config.py
@@ -4,6 +4,9 @@ from typing import Any, Dict, TYPE_CHECKING
 
 import discord
 
+from core.models import getLogger
+from core.utils import tryint
+
 from ..discord.ext.modmail_utils import Config
 
 
@@ -11,6 +14,9 @@ if TYPE_CHECKING:
     from motor.motor_asyncio import AsyncIOMotorCollection
 
     from ..utils import ExtendedUtils
+
+
+logger = getLogger(__name__)
 
 
 _default_config: Dict[str, Any] = {
@@ -48,6 +54,8 @@ class UtilsConfig(Config):
             if isinstance(item, (_enums[key])):
                 # value is an enum type
                 item = item.value
+            else:
+                item = tryint(item)
         if key in _optional:
             if isinstance(item, str) and item.lower() == "none":
                 item = None
@@ -68,5 +76,9 @@ class UtilsConfig(Config):
         if key in _enums:
             if value is None:
                 return None
-            value = _enums[key](value)
+            try:
+                value = _enums[key](tryint(value))
+            except ValueError:
+                logger.warning(f"{value} is invalid for key {key}.")
+                value = self.remove(key)
         return value

--- a/utils/core/config.py
+++ b/utils/core/config.py
@@ -47,27 +47,27 @@ _optional = {
 _config_info = {
     "confirm_button_accept_label": {
         "description": "Label for accept confirmation button.",
-        "examples": ["`{prefix}{command} {key} Confirm`"],
+        "examples": ["`{prefix}{config_set} {key} Confirm`"],
     },
     "confirm_button_accept_emoji": {
         "description": "Emoji for accept confirmation button.",
-        "examples": ["`{prefix}{command} {key} ✅`"],
+        "examples": ["`{prefix}{config_set} {key} ✅`"],
     },
     "confirm_button_accept_style": {
         "description": "Button color style. The only available options are as follows:\n- `1` - Blurple\n- `2` - Grey\n- `3` - Green\n- `4` - Red",
-        "examples": ["`{prefix}{command} {key} 1`"],
+        "examples": ["`{prefix}{config_set} {key} 1`"],
     },
     "confirm_button_deny_label": {
         "description": "Label for deny confirmation button.",
-        "examples": ["`{prefix}{command} {key} Cancel`"],
+        "examples": ["`{prefix}{config_set} {key} Cancel`"],
     },
     "confirm_button_deny_emoji": {
         "description": "Emoji for accept confirmation button.",
-        "examples": ["`{prefix}{command} {key} ❌`"],
+        "examples": ["`{prefix}{config_set} {key} ❌`"],
     },
     "confirm_button_deny_style": {
         "description": "Button color style. The only available options are as follows:\n- `1` - Blurple\n- `2` - Grey\n- `3` - Green\n- `4` - Red",
-        "examples": ["`{prefix}{command} {key} 1`"],
+        "examples": ["`{prefix}{config_set} {key} 1`"],
     },
 }
 

--- a/utils/core/config.py
+++ b/utils/core/config.py
@@ -133,6 +133,9 @@ class UtilsConfig(Config):
         """
         key = key.lower()
         if key not in _default_config:
+            if default is not None:
+                # do nothing
+                pass
             raise KeyError(f"{key} is invalid key.")
         if key not in self._cache:
             self._cache[key] = self.deepcopy(_default_config[key])

--- a/utils/core/config.py
+++ b/utils/core/config.py
@@ -44,20 +44,38 @@ _optional = {
     "confirm_button_deny_emoji",
 }
 
-_config_descriptions = {
-    "confirm_button_accept_label": "Label for accept confirmation button.",
-    "confirm_button_accept_emoji": "Emoji for accept confirmation button.",
-    "confirm_button_accept_style": "Button color style. The only available options are as follows:\n\t-`1` - Blurple\n\t-`2` - Grey\n\t-`3` - Green\n\t-`4` - Red",
-    "confirm_button_deny_label": "Label for deny confirmation button.",
-    "confirm_button_deny_emoji": "Emoji for accept confirmation button.",
-    "confirm_button_deny_style": "Button color style. The only available options are as follows:\n\t-`1` - Blurple\n\t-`2` - Grey\n\t-`3` - Green\n\t-`4` - Red",
+_config_info = {
+    "confirm_button_accept_label": {
+        "description": "Label for accept confirmation button.",
+        "examples": ["`{prefix}{command} {key} Confirm`"],
+    },
+    "confirm_button_accept_emoji": {
+        "description": "Emoji for accept confirmation button.",
+        "examples": ["`{prefix}{command} {key} ✅`"],
+    },
+    "confirm_button_accept_style": {
+        "description": "Button color style. The only available options are as follows:\n- `1` - Blurple\n- `2` - Grey\n- `3` - Green\n- `4` - Red",
+        "examples": ["`{prefix}{command} {key} 1`"],
+    },
+    "confirm_button_deny_label": {
+        "description": "Label for deny confirmation button.",
+        "examples": ["`{prefix}{command} {key} Cancel`"],
+    },
+    "confirm_button_deny_emoji": {
+        "description": "Emoji for accept confirmation button.",
+        "examples": ["`{prefix}{command} {key} ❌`"],
+    },
+    "confirm_button_deny_style": {
+        "description": "Button color style. The only available options are as follows:\n- `1` - Blurple\n- `2` - Grey\n- `3` - Green\n- `4` - Red",
+        "examples": ["`{prefix}{command} {key} 1`"],
+    },
 }
 
 
 class UtilsConfig(Config):
     def __init__(self, cog: ExtendedUtils, db: AsyncIOMotorCollection):
         super().__init__(cog, db, defaults=_default_config)
-        self.config_descriptions: Dict[str, str] = _config_descriptions
+        self.config_info: Dict[str, str] = _config_info
 
     def set(self, key: str, item: Any) -> None:
         """

--- a/utils/core/config.py
+++ b/utils/core/config.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Dict, TYPE_CHECKING
+
+import discord
+
+from ..discord.ext.modmail_utils import Config
+
+
+if TYPE_CHECKING:
+    from motor.motor_asyncio import AsyncIOMotorCollection
+
+    from ..utils import ExtendedUtils
+
+
+_default_config: Dict[str, Any] = {
+    "confirm_button_accept_label": None,
+    "confirm_button_accept_emoji": None,
+    "confirm_button_accept_style": discord.ButtonStyle.green.value,
+    "confirm_button_deny_label": None,
+    "confirm_button_deny_emoji": None,
+    "confirm_button_deny_style": discord.ButtonStyle.red.value,
+}
+
+_enums = {
+    "confirm_button_accept_style": discord.ButtonStyle,
+    "confirm_button_deny_style": discord.ButtonStyle,
+}
+
+# keys that accept `None` as value
+_optional = {
+    "confirm_button_accept_label",
+    "confirm_button_accept_emoji",
+    "confirm_button_deny_label",
+    "confirm_button_deny_emoji",
+}
+
+
+class UtilsConfig(Config):
+    def __init__(self, cog: ExtendedUtils, db: AsyncIOMotorCollection):
+        super().__init__(cog, db, defaults=_default_config)
+
+    def set(self, key: str, item: Any) -> None:
+        """
+        Sets an item.
+        """
+        if key in _enums:
+            if isinstance(item, (_enums[key])):
+                # value is an enum type
+                item = item.value
+        if key in _optional:
+            if isinstance(item, str) and item.lower() == "none":
+                item = None
+
+        return self.__setitem__(key, item)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """
+        Gets an item from config.
+        """
+        key = key.lower()
+        if key not in _default_config:
+            raise KeyError(f"{key} is invalid key.")
+        if key not in self._cache:
+            self._cache[key] = self.deepcopy(_default_config[key])
+        value = self._cache[key]
+
+        if key in _enums:
+            if value is None:
+                return None
+            value = _enums[key](value)
+        return value

--- a/utils/discord/ext/modmail_utils/__init__.py
+++ b/utils/discord/ext/modmail_utils/__init__.py
@@ -1,6 +1,6 @@
 __title__ = "modmail_utils"
 __author__ = "Jerrie-Aries"
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 __license__ = "AGPL"
 
 from .chat_formatting import *

--- a/utils/discord/ext/modmail_utils/converters.py
+++ b/utils/discord/ext/modmail_utils/converters.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Optional, Union, TYPE_CHECKING
+from typing import Any, Optional, Union, TYPE_CHECKING
 
 import discord
 from discord.ext import commands

--- a/utils/discord/ext/modmail_utils/converters.py
+++ b/utils/discord/ext/modmail_utils/converters.py
@@ -12,9 +12,41 @@ if TYPE_CHECKING:
     from bot import ModmailBot
 
 
+__all__ = ("EmojiConverter", "convert_emoji")
+
 EmojiT = Union[discord.Emoji, discord.PartialEmoji]
 
-__all__ = ("EmojiConverter",)
+
+def convert_emoji(bot: ModmailBot, name: str) -> EmojiT:
+    """
+    A function to convert the provided string to a :class:`discord.Emoji`, :class:`discord.PartialEmoji`.
+
+    If the parsed emoji has an ID (a custom emoji) and cannot be found, or does not have an ID and
+    cannot be found in :class:`EMOJI_DATA` dictionary keys, :class:`commands.EmojiNotFound`
+    will be raised.
+
+    Parameters
+    -----------
+    name : str
+        The emoji string or a unicode emoji.
+
+    Returns
+    -------
+    :class:`discord.Emoji` or :class:`discord.PartialEmoji`
+        The converted emoji.
+    """
+    # remove trailing whitespace
+    name = re.sub("\ufe0f", "", name)
+    emoji = discord.PartialEmoji.from_str(name)
+    if emoji.is_unicode_emoji():
+        if emoji.name not in EMOJI_DATA:
+            raise ValueError(f"{name} is not a valid unicode emoji.")
+    else:
+        # custom emoji
+        emoji = bot.get_emoji(emoji.id)
+        if emoji is None:
+            raise commands.EmojiNotFound(name)
+    return emoji
 
 
 class EmojiConverter(commands.Converter):
@@ -24,38 +56,6 @@ class EmojiConverter(commands.Converter):
 
     async def convert(self, ctx: commands.Context, argument: str) -> EmojiT:
         try:
-            return self._convert_emoji(ctx.bot, argument)
+            return convert_emoji(ctx.bot, argument)
         except commands.BadArgument:
             raise commands.EmojiNotFound(argument)
-
-    @staticmethod
-    def _convert_emoji(bot: ModmailBot, name: str) -> EmojiT:
-        """
-        A method to convert the provided string to a :class:`discord.Emoji`, :class:`discord.PartialEmoji`.
-
-        If the parsed emoji has an ID (a custom emoji) and cannot be found, or does not have an ID and
-        cannot be found in :class:`EMOJI_DATA` dictionary keys, :class:`commands.EmojiNotFound`
-        will be raised.
-
-        Parameters
-        -----------
-        name : str
-            The emoji string or a unicode emoji.
-
-        Returns
-        -------
-        :class:`discord.Emoji` or :class:`discord.PartialEmoji`
-            The converted emoji.
-        """
-        # remove trailing whitespace
-        name = re.sub("\ufe0f", "", name)
-        emoji = discord.PartialEmoji.from_str(name)
-        if emoji.is_unicode_emoji():
-            if emoji.name not in EMOJI_DATA:
-                raise ValueError(f"{name} is not a valid unicode emoji.")
-        else:
-            # custom emoji
-            emoji = bot.get_emoji(emoji.id)
-            if emoji is None:
-                raise commands.EmojiNotFound(name)
-        return emoji

--- a/utils/info.json
+++ b/utils/info.json
@@ -5,7 +5,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "requirements": []

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -150,15 +150,15 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
             text = f.read()
         return re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', text, re.MULTILINE).group(1)
 
-    @commands.group(name="extutils", aliases=["eutils"], invoke_without_command=True)
+    @commands.group(aliases=["extutils"], invoke_without_command=True)
     @checks.has_permissions(PermissionLevel.OWNER)
-    async def ext_utils(self, ctx: commands.Context):
+    async def eutils(self, ctx: commands.Context):
         """
         Extended Utils base command.
         """
         await ctx.send_help(ctx.command)
 
-    @ext_utils.command(name="info")
+    @eutils.command(name="info")
     @checks.has_permissions(PermissionLevel.OWNER)
     async def utils_info(self, ctx: commands.Context):
         """
@@ -179,7 +179,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
         embed.set_footer(text=f"{__plugin_name__}: v{__version__}")
         await ctx.send(embed=embed)
 
-    @ext_utils.command(name="update")
+    @eutils.command(name="update")
     @checks.has_permissions(PermissionLevel.OWNER)
     async def utils_update(self, ctx: commands.Context):
         """
@@ -210,7 +210,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
         embed.description = description
         await msg.edit(embed=embed)
 
-    @ext_utils.command(name="reorder", hidden=True)
+    @eutils.command(name="reorder", hidden=True)
     @checks.has_permissions(PermissionLevel.OWNER)
     async def utils_reorder(self, ctx: commands.Context):
         """
@@ -261,7 +261,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
         await ctx.send(embed=embed)
 
     # these were adapted from cogs/utility.py
-    @ext_utils.group(name="config", invoke_without_command=True)
+    @eutils.group(name="config", usage="[subcommand]", invoke_without_command=True)
     @checks.has_permissions(PermissionLevel.OWNER)
     async def utils_config(self, ctx: commands.Context):
         """
@@ -269,6 +269,9 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
 
         To set a configuration:
         - `{prefix}eutils config set config-name value`
+
+        To get a configuration value:
+        - `{prefix}eutils config get config-name`
 
         To remove a configuration:
         - `{prefix}eutils config remove config-name`
@@ -377,7 +380,10 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
 
         def fmt(val: str) -> str:
             return UnseenFormatter().format(
-                val, prefix=self.bot.prefix, command="eutils config set", key=current_key
+                val,
+                prefix=self.bot.prefix,
+                config_set=f"{ctx.command.parent.qualified_name} set",
+                key=current_key,
             )
 
         for i, (current_key, info) in enumerate(config_info.items()):

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -342,7 +342,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
         Delete a set configuration variable.
         """
         if key in self.config.defaults:
-            self.config.remove(key)
+            self.config.remove(key, restore_default=True)
             await self.config.update()
             embed = discord.Embed(
                 title="Success",

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -369,7 +369,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
 
         Leave `key` unspecified to show all available config options and informations.
         """
-        if key is not None and not (key in self.config.defaults):
+        if key is not None and key not in self.config.defaults:
             raise commands.BadArgument(f"`{key}` is an invalid key.")
 
         config_info = self.config.config_info

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -313,7 +313,7 @@ class ExtendedUtils(commands.Cog, name=__plugin_name__):
         """
         if key:
             if key in self.config.defaults:
-                desc = f"`{key}` is set to `{self.bot.config[key]}`"
+                desc = f"`{key}` is set to `{self.config[key]}`"
                 embed = discord.Embed(color=self.bot.main_color, description=desc)
                 embed.set_author(name="Config variable", icon_url=self.bot.user.display_avatar.url)
 


### PR DESCRIPTION
### Changelog

**Plugin:**
- Add new folder and file, `core/config.py`.
- Rename `?ext_utils` command to `eutils` with alias `extutils`.
- Add `?eutils config` command and subcommands. These were adapted from core bot. Its subcommands are:
  - `set`
  - `get`
  - `remove`
  - `help`
- Config values are stored in database.
- Developer channel feature where bot owners no longer need to use prefixes to execute commands.
 
**Package:**
`modmail_utils` package v0.1.9:
- Configurable `ConfirmView`.
- Converters:
  - Make `convert_emoji` public and can be imported.
  - Add `convert_text_channel` and `get_id_match` functions. Both are public and can be imported. Those were adapted from the ones in `discord.py`.