### PR TITLE
`supportutils` plugin v1.5.0

### DIFF
--- a/supportutils/core/config.py
+++ b/supportutils/core/config.py
@@ -26,10 +26,13 @@ _default_config: Dict[str, Any] = {
             "placeholder": "Choose a category",
         },
         "override_dmdisabled": False,
-        "confirmation_embed": {
-            "title": "Confirm thread creation",
-            "description": "Use the button below to confirm thread creation which will directly contact the moderators.",
-            "footer": None,
+        "confirmation": {
+            "enable": True,  # not used for now
+            "embed": {
+                "title": "Confirm thread creation",
+                "description": "Use the button below to confirm thread creation which will directly contact the moderators.",
+                "footer": None,
+            },
         },
     },
     "feedback": {
@@ -56,7 +59,8 @@ class SupportUtilityConfig(Config):
         await super().fetch()
         self.recursively_resolve_keys(self.defaults, self._cache)
 
-    # if this works, implement this in utils
+    # TODO: if this works, implement this in utils
+    # then this can be removed
     def recursively_resolve_keys(self, base: Dict[str, Any], data: Dict[str, Any]) -> None:
         for key, value in base.items():
             if key not in data:

--- a/supportutils/core/config.py
+++ b/supportutils/core/config.py
@@ -25,6 +25,7 @@ _default_config: Dict[str, Any] = {
             "options": [],
             "placeholder": "Choose a category",
         },
+        "override_dmdisabled": False,
     },
     "feedback": {
         "enable": False,

--- a/supportutils/core/config.py
+++ b/supportutils/core/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from discord.ext.modmail_utils import Config
 
@@ -26,6 +26,11 @@ _default_config: Dict[str, Any] = {
             "placeholder": "Choose a category",
         },
         "override_dmdisabled": False,
+        "confirmation_embed": {
+            "title": "Confirm thread creation",
+            "description": "Use the button below to confirm thread creation which will directly contact the moderators.",
+            "footer": None,
+        },
     },
     "feedback": {
         "enable": False,
@@ -46,6 +51,20 @@ _default_config: Dict[str, Any] = {
 class SupportUtilityConfig(Config):
     def __init__(self, cog: SupportUtility, db: AsyncIOMotorCollection):
         super().__init__(cog, db, defaults=_default_config)
+
+    async def fetch(self) -> Dict[str, Any]:
+        await super().fetch()
+        self.recursively_resolve_keys(self.defaults, self._cache)
+
+    # if this works, implement this in utils
+    def recursively_resolve_keys(self, base: Dict[str, Any], data: Dict[str, Any]) -> None:
+        for key, value in base.items():
+            if key not in data:
+                data[key] = self.deepcopy(value)
+                continue
+            if isinstance(value, dict):
+                # go deeper
+                self.recursively_resolve_keys(value, data[key])
 
     @property
     def contact(self) -> Dict[str, Any]:

--- a/supportutils/core/views.py
+++ b/supportutils/core/views.py
@@ -182,7 +182,10 @@ class ContactView(BaseView):
             embed.description = content
         elif await self.bot.is_blocked(user):
             embed.description = f"You are currently blocked from contacting {self.bot.user.name}."
-        elif self.bot.config["dm_disabled"] in (DMDisabled.NEW_THREADS, DMDisabled.ALL_THREADS):
+        elif (
+            self.bot.config["dm_disabled"] == DMDisabled.NEW_THREADS
+            and not self.manager.config.get("override_dmdisabled")
+        ) or self.bot.config["dm_disabled"] == DMDisabled.ALL_THREADS:
             embed.description = self.bot.config["disabled_new_thread_response"]
             logger.info(
                 "A new thread using contact menu was blocked from %s due to disabled Modmail.",

--- a/supportutils/core/views.py
+++ b/supportutils/core/views.py
@@ -59,6 +59,7 @@ class DropdownMenu(ui.Select):
         option = self.get_option(self.values[0])
         for opt in self.options:
             opt.default = opt.value in self.values
+        self.view.interaction = interaction
         await self.followup_callback(interaction, self, option=option)
 
     def get_option(self, value: str) -> discord.SelectOption:
@@ -253,10 +254,8 @@ class ContactView(BaseView):
         if not view.value:
             self._temp_cached_users.pop(str(user.id), None)
             return
-
         if view.inputs:
             option = view.inputs["contact_option"]
-            interaction = view.inputs["interaction"]
             category_id = None
             for data in self.select_options:
                 if data.get("label") == option.label:
@@ -269,7 +268,7 @@ class ContactView(BaseView):
                 # just log, the thread will be created in main category
                 logger.error(f"Category with ID {category_id} not found.")
 
-        await self.manager.create_thread(user, category=category, interaction=interaction)
+        await self.manager.create_thread(user, category=category, interaction=view.interaction)
         self._temp_cached_users.pop(str(user.id), None)
 
     async def force_stop(self) -> None:

--- a/supportutils/core/views.py
+++ b/supportutils/core/views.py
@@ -74,8 +74,15 @@ class BaseView(View):
     Base view class.
     """
 
-    def __init__(self, cog: SupportUtility, *, message: discord.Message = MISSING, timeout: float = 300.0):
-        super().__init__(message=message, timeout=timeout)
+    def __init__(
+        self,
+        cog: SupportUtility,
+        *,
+        message: discord.Message = MISSING,
+        timeout: float = 300.0,
+        **kwargs: Any,
+    ):
+        super().__init__(message=message, timeout=timeout, **kwargs)
         self.cog: SupportUtility = cog
         self.bot: ModmailBot = cog.bot
 
@@ -87,11 +94,11 @@ class BaseView(View):
 
 
 class SupportUtilityView(BaseView):
-    def __init__(self, ctx: commands.Context, *, input_session: str = MISSING):
+    def __init__(self, ctx: commands.Context, *, extras: Dict[str, Any] = MISSING):
         self.ctx: commands.Context = ctx
         self.user: discord.Member = ctx.author
-        super().__init__(ctx.cog)
-        self.input_session: str = input_session
+        super().__init__(ctx.cog, extras=extras)
+        self.outputs: Dict[str, Any] = {}
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user != self.user:
@@ -234,13 +241,13 @@ class ContactView(BaseView):
             view.add_item(view.accept_button)
             view.add_item(view.deny_button)
 
-        confirm_config = self.manager.config["confirmation_embed"]
+        embed_config = self.manager.config["confirmation"]["embed"]
         embed = discord.Embed(
-            title=confirm_config["title"],
-            description=confirm_config["description"],
+            title=embed_config["title"],
+            description=embed_config["description"],
             color=self.bot.main_color,
         )
-        footer = confirm_config["footer"]
+        footer = embed_config["footer"]
         if footer:
             embed.set_footer(text=footer)
         await interaction.response.send_message(

--- a/supportutils/info.json
+++ b/supportutils/info.json
@@ -8,7 +8,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "0.4.7",
+    "version": "0.5.0",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/supportutils/info.json
+++ b/supportutils/info.json
@@ -8,7 +8,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "author": "Jerrie-Aries",
-    "version": "0.4.6",
+    "version": "0.4.7",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -705,6 +705,39 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         )
         await ctx.send(embed=embed)
 
+    @cm_config.command(name="override_dmdisabled", aliases=["ignore_dmdisabled"])
+    @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
+    async def cm_config_override_dmdisabled(self, ctx: commands.Context, *, mode: Optional[bool] = None):
+        """
+        Enable or disable the override of DM disabled.
+
+        `mode` may be `True` or `False` (case insensitive).
+        Leave `mode` empty to retrieve the current set value.
+
+        __**Note:**__
+        - This can only override the disable new thread setting.
+        """
+        config = self.config.contact
+        enabled = config.get("override_dmdisabled", False)
+        if mode is None:
+            embed = discord.Embed(
+                color=self.bot.main_color,
+                description="DM disabled override is currently " + ("enabled." if enabled else "disabled."),
+            )
+            return await ctx.send(embed=embed)
+        if mode == enabled:
+            raise commands.BadArgument(
+                "DM disabled override is already " + ("enabled." if enabled else "disabled.")
+            )
+
+        config["override_dmdisabled"] = mode
+        await self.config.update()
+        embed = discord.Embed(
+            color=self.bot.main_color,
+            description="DM disabled override is now " + ("enabled." if mode else "disabled."),
+        )
+        await ctx.send(embed=embed)
+
     @cm_config.command(name="clear")
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def cm_config_clear(self, ctx: commands.Context):

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -441,17 +441,13 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         embed = discord.Embed(
             title="Contact embed",
             color=self.bot.main_color,
-            description=ctx.command.help.format(prefix=self.bot.prefix),
+            description=ctx.command.help.format(prefix=self.bot.prefix) + "\n\n",
         )
         embed.set_footer(text="Press Set to set/edit the values")
         embed_config = self.config.contact.get("embed")
-        embed.add_field(
-            name="Current values",
-            value="\n".join(
-                f"- **{key.title()}** : `{truncate(str(embed_config.get(key)), max=256)}`"
-                for key in ("title", "description", "footer")
-            ),
-        )
+        embed.description += "### Current values"
+        for key in ("title", "description", "footer"):
+            embed.add_field(name=key.title(), value=f"`{truncate(str(embed_config.get(key)), max=256)}`")
         view = self.get_config_view(ctx, title=embed.title, keys=["contact", "embed"])
         view.message = message = await ctx.send(embed=embed, view=view)
 
@@ -460,16 +456,15 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
 
         if view.value:
             payload = view.outputs
-            updated = []
-            for key in list(payload):
-                updated.append(f"- **{key.title()}** : `{truncate(str(payload[key]), max=1024)}`")
-                self.config.contact["embed"][key] = payload.pop(key)
-            await self.config.update()
             embed = discord.Embed(
-                description="Successfully set the new configurations for contact menu embed.\n\n"
-                + "\n".join(updated),
+                description="Successfully set the new configurations for contact menu embed.\n\n",
                 color=self.bot.main_color,
             )
+            embed.description += "### New values"
+            for key in list(payload):
+                embed.add_field(name=key.title(), value=f"`{truncate(str(payload[key]), max=1024)}`")
+                self.config.contact["embed"][key] = payload.pop(key)
+            await self.config.update()
             await view.interaction.followup.send(embed=embed)
 
     @cm_config_embed.command(name="clear")
@@ -513,16 +508,13 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         embed = discord.Embed(
             title="Contact button",
             color=self.bot.main_color,
-            description=description,
+            description=description + "\n\n",
         )
         embed.set_footer(text="Press Set to set/edit the values")
         button_config = self.config.contact.get("button")
-        embed.add_field(
-            name="Current values",
-            value="\n".join(
-                f"- **{key.title()}** : `{button_config.get(key)}`" for key in ("emoji", "label", "style")
-            ),
-        )
+        embed.description += "### Current values"
+        for key in ("emoji", "label", "style"):
+            embed.add_field(name=key.title(), value=f"`{button_config.get(key)}`")
         view = self.get_config_view(ctx, title=embed.title, keys=["contact", "button"])
         view.message = message = await ctx.send(embed=embed, view=view)
 
@@ -531,16 +523,15 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
 
         if view.value:
             payload = view.outputs
-            updated = []
-            for key in list(payload):
-                updated.append(f"- **{key.title()}** : `{payload[key]}`")
-                self.config.contact["button"][key] = payload.pop(key)
-            await self.config.update()
             embed = discord.Embed(
-                description="Successfully set the new configurations for contact button.\n\n"
-                + "\n".join(updated),
+                description="Successfully set the new configurations for contact button.\n\n",
                 color=self.bot.main_color,
             )
+            embed.description += "### New values"
+            for key in list(payload):
+                embed.add_field(name=key.title(), value=f"`{payload[key]}`")
+                self.config.contact["button"][key] = payload.pop(key)
+            await self.config.update()
             await view.interaction.followup.send(embed=embed)
 
     @cm_config_button.command(name="clear")
@@ -638,16 +629,16 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
             return
 
         payload = {}
-        updated = []
+        embed = discord.Embed(
+            color=self.bot.main_color,
+            description="Successfully added a dropdown option.\n\n",
+        )
+        embed.description += "### New option"
         for key in list(view.outputs):
-            updated.append(f"- **{key.title()}** : `{view.outputs[key]}`")
+            embed.add_field(name=key.title(), value=f"`{view.outputs[key]}`")
             payload[key] = view.outputs.pop(key)
         self.config.contact["select"]["options"].append(payload)
         await self.config.update()
-        embed = discord.Embed(
-            color=self.bot.main_color,
-            description="Successfully added a dropdown option:\n\n" + "\n".join(updated),
-        )
         await view.interaction.followup.send(embed=embed)
 
     @cm_config_dropdown.command(name="list")
@@ -727,17 +718,13 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         embed = discord.Embed(
             title="Confirmation embed",
             color=self.bot.main_color,
-            description=ctx.command.help.format(prefix=self.bot.prefix),
+            description=ctx.command.help.format(prefix=self.bot.prefix) + "\n\n",
         )
         embed.set_footer(text="Press Set to set/edit the values")
         embed_config = self.config.contact["confirmation"]["embed"]
-        embed.add_field(
-            name="Current values",
-            value="\n".join(
-                f"- **{key.title()}** : `{truncate(str(embed_config.get(key)), max=256)}`"
-                for key in ("title", "description", "footer")
-            ),
-        )
+        embed.description += "### Current values"
+        for key in ("title", "description", "footer"):
+            embed.add_field(name=key.title(), value=f"`{truncate(str(embed_config.get(key)), max=256)}`")
         view = self.get_config_view(ctx, title=embed.title, keys=["contact", "confirmation", "embed"])
         view.message = message = await ctx.send(embed=embed, view=view)
 
@@ -746,21 +733,20 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
 
         if view.value:
             payload = view.outputs
-            updated = []
-            for key in list(payload):
-                updated.append(f"- **{key.title()}** : `{truncate(str(payload[key]), max=1024)}`")
-                embed_config[key] = payload.pop(key)
-            await self.config.update()
             embed = discord.Embed(
-                description="Successfully set the new configurations for thread creation confirmation embed.\n\n"
-                + "\n".join(updated),
+                description="Successfully set the new configurations for thread creation confirmation embed.\n\n",
                 color=self.bot.main_color,
             )
+            embed.description += "### New values"
+            for key in list(payload):
+                embed.add_field(name=key.title(), value=f"`{truncate(str(payload[key]), max=1024)}`")
+                self.config.contact["confirmation"]["embed"][key] = payload.pop(key)
+            await self.config.update()
             await view.interaction.followup.send(embed=embed)
 
     @cm_config_confirmembed.command(name="clear")
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
-    async def cm_config_embed_clear(self, ctx: commands.Context):
+    async def cm_config_confirmembed_clear(self, ctx: commands.Context):
         """
         Clear the thread creation confirmation embed configurations and reset to default values.
         """
@@ -1035,17 +1021,13 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         embed = discord.Embed(
             title="Feedback embed",
             color=self.bot.main_color,
-            description=ctx.command.help,
+            description=ctx.command.help + "\n\n",
         )
         embed.set_footer(text="Press Set to set/edit the values")
         embed_config = self.config.feedback.get("embed")
-        embed.add_field(
-            name="Current values",
-            value="\n".join(
-                f"- **{key.title()}** : `{truncate(str(embed_config.get(key)), max=256)}`"
-                for key in ("title", "description", "footer")
-            ),
-        )
+        embed.description += "### Current values"
+        for key in ("title", "description", "footer"):
+            embed.add_field(name=key.title(), value=f"`{truncate(str(embed_config.get(key)), max=256)}`")
         view = self.get_config_view(ctx, title=embed.title, keys=["feedback", "embed"])
         view.message = message = await ctx.send(embed=embed, view=view)
 
@@ -1054,16 +1036,15 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
 
         if view.value:
             payload = view.outputs
-            updated = []
-            for key in list(payload):
-                updated.append(f"- **{key.title()}** : `{truncate(str(payload[key]), max=1024)}`")
-                self.config.feedback["embed"][key] = payload.pop(key)
-            await self.config.update()
             embed = discord.Embed(
-                description="Successfully set the new configurations for feedback embed.\n\n"
-                + "\n".join(updated),
+                description="Successfully set the new configurations for feedback embed.\n\n",
                 color=self.bot.main_color,
             )
+            embed.description += "### New values"
+            for key in list(payload):
+                embed.add_field(name=key.title(), value=f"`{truncate(str(payload[key]), max=1024)}`")
+                self.config.feedback["embed"][key] = payload.pop(key)
+            await self.config.update()
             await view.interaction.followup.send(embed=embed)
 
     @fb_config_embed.command(name="clear")
@@ -1107,16 +1088,13 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         embed = discord.Embed(
             title="Feedback button",
             color=self.bot.main_color,
-            description=description,
+            description=description + "\n\n",
         )
         embed.set_footer(text="Press Set to set/edit the values")
         feedback_config = self.config.feedback.get("button")
-        embed.add_field(
-            name="Current values",
-            value="\n".join(
-                f"- **{key.title()}** : `{feedback_config.get(key)}`" for key in ("emoji", "label", "style")
-            ),
-        )
+        embed.description += "### Current values"
+        for key in ("emoji", "label", "style"):
+            embed.add_field(name=key.title(), value=f"`{feedback_config.get(key)}`")
         view = self.get_config_view(ctx, title=embed.title, keys=["feedback", "button"])
         view.message = message = await ctx.send(embed=embed, view=view)
 
@@ -1125,16 +1103,15 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
 
         if view.value:
             payload = view.outputs
-            updated = []
-            for key in list(payload):
-                updated.append(f"- **{key.title()}** : `{payload[key]}`")
-                self.config.feedback["button"][key] = payload.pop(key)
-            await self.config.update()
             embed = discord.Embed(
-                description="Successfully set the new configurations for feedback button.\n\n"
-                + "\n".join(updated),
+                description="Successfully set the new configurations for feedback button.\n\n",
                 color=self.bot.main_color,
             )
+            embed.description += "### New values"
+            for key in list(payload):
+                embed.add_field(name=key.title(), value=f"`{payload[key]}`")
+                self.config.feedback["button"][key] = payload.pop(key)
+            await self.config.update()
             await view.interaction.followup.send(embed=embed)
 
     @fb_config_button.command(name="clear")

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -116,6 +116,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
                     "default": view.inputs.get(subkey) or getattr(self.config, prefix, {})[key].get(subkey),
                 }
             else:
+                # select options
                 elements = [
                     ("emoji", 256),
                     ("label", Limit.button_label),
@@ -1242,7 +1243,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         current = self.config.feedback["rating"]["placeholder"]
         embed.add_field(name="Current value", value=f"`{current}`")
         embed.set_footer(text="Press Set to set/edit the dropdown placeholder")
-        view = self.get_config_view(ctx, title=embed.title, keys=["rating", "placeholder"])
+        view = self.get_config_view(ctx, title=embed.title, keys=["feedback", "rating", "placeholder"])
         view.message = message = await ctx.send(embed=embed, view=view)
 
         await view.wait()


### PR DESCRIPTION
### Changelog

__**Added**__
- Add `?conmenu config confirmembed`. This is to customise the confirmation embed that is sent to user after pressing the Contact button. Customisable options are title, description and footer.
- Add `override_dmdisabled` option. If set to `True` the thread will still be created after pressing the Contact button even when the `?disable new` is set. To enable this override, use command `?conmenu config override_dmdisabled True`.

__**Changed**__
- The category select dropdown for contact menu is now shown with confirmation message. No longer double pop up messages after pressing the Contact button.

__**Internal**__
- Recursively check for missing new config keys in the config data fetched from database. If any new key is missing, the default will be restored and cached without updating the database.


### Notes
- These were tested with `utils` plugin v1.3.0. This may not work if `utils` is lower than v1.2.1. If your `utils` is lower than that, **make sure to update `utils` first**. Check the version in help menu with command:
  - `?help Extended Utils`
- If your bot is on `master` branch and/or v4.0.2 and lower, you may need to restart the bot after updating the plugins.