### PR TITLE
Resolve default keys

### DIFF
--- a/invites/info.json
+++ b/invites/info.json
@@ -8,8 +8,8 @@
         "- Check invite's uses. If used invite is found with this method, it will overwrite any results from the previous method.",
         "\n**Version:**\n`{0}`"
     ],
-    "author": "Jerrie-Aries",
-    "version": "2.0.0",
+    "author": ["Jerrie-Aries"],
+    "version": "2.0.1",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/invites/info.json
+++ b/invites/info.json
@@ -8,7 +8,7 @@
         "- Check invite's uses. If used invite is found with this method, it will overwrite any results from the previous method.",
         "\n**Version:**\n`{0}`"
     ],
-    "author": ["Jerrie-Aries"],
+    "authors": ["Jerrie-Aries"],
     "version": "2.0.1",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",

--- a/moderation/core/config.py
+++ b/moderation/core/config.py
@@ -34,8 +34,7 @@ class GuildConfig(BaseConfig):
         super().__init__(cog, defaults=_default_config)
         self.guild: discord.Guild = guild
         self.webhook: discord.Webhook = MISSING
-        self._cache = data
-        self._recursive_resolve_keys(self.defaults, self._cache)
+        self._cache: Dict[str, Any] = data
 
     def __hash__(self):
         return hash((self.guild.id,))
@@ -106,6 +105,6 @@ class ModConfig(Config):
         """Returns config for the guild specified."""
         config = next((c for c in self.__guild_configs if c.guild.id == guild.id), None)
         if config is None:
-            config = GuildConfig(self.cog, guild, data={})
+            config = GuildConfig(self.cog, guild, data=self.deepcopy(_default_config))
             self.__guild_configs.add(config)
         return config

--- a/moderation/core/config.py
+++ b/moderation/core/config.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional, Set, TYPE_CHECKING
 
 import discord
 from discord.utils import MISSING
 
-from discord.ext.modmail_utils import Config
+from discord.ext.modmail_utils import BaseConfig, Config
 
 
 if TYPE_CHECKING:
@@ -14,7 +14,10 @@ if TYPE_CHECKING:
     from ..moderation import Moderation
 
 
-DEFAULT_CONFIG = {
+__all__ = ("GuildConfig", "ModConfig")
+
+
+_default_config = {
     "log_channel": str(int()),
     "logging": False,
     "webhook": None,
@@ -22,46 +25,87 @@ DEFAULT_CONFIG = {
 }
 
 
-# Configuration
-class ModConfig(Config):
+class GuildConfig(BaseConfig):
     """
-    A class to handle Mod's configurations per guild.
+    Config instance for a guild.
     """
 
-    cog: Moderation
-
-    def __init__(
-        self,
-        cog: Moderation,
-        db: AsyncIOMotorCollection,
-        guild: discord.Guild,
-        *,
-        data: Dict[str, Any],
-    ):
+    def __init__(self, cog: Moderation, guild: discord.Guild, data: Dict[str, Any]):
+        super().__init__(cog, defaults=_default_config)
         self.guild: discord.Guild = guild
-        defaults = {k: v for k, v in DEFAULT_CONFIG.items()}
-        super().__init__(cog, db, defaults=defaults)
-        self._cache: Dict[str, Any] = data if data else self.copy(self.defaults)
         self.webhook: discord.Webhook = MISSING
+        self._cache = data
+        self._recursive_resolve_keys(self.defaults, self._cache)
+
+    def __hash__(self):
+        return hash((self.guild.id,))
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} guild_id={self.guild.id} cache={self.cache}>"
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, GuildConfig):
+            return False
+        return self.guild.id == other.guild.id
 
     async def update(self) -> None:
         """
         Updates the database with config from cache.
         """
-        await super().update(data={str(self.guild.id): self._cache})
+        await self.cog.config.update(data={str(self.guild.id): self._cache})
 
     @property
     def log_channel(self) -> Optional[discord.TextChannel]:
         """
         Returns the log channel.
         """
-        channel_id = self.get("log_channel")
+        channel_id = int(self.get("log_channel"))
+        if not channel_id:
+            return None
         return self.guild.get_channel(int(channel_id))
 
     def remove(self, key: str) -> Any:
-        if key not in DEFAULT_CONFIG:
+        if key not in _default_config:
             raise KeyError(f'Configuration key "{key}" is invalid.')
         if key in self.cache:
             del self._cache[key]
 
-        self._cache[key] = self.copy(DEFAULT_CONFIG[key])
+        self._cache[key] = self.copy(_default_config[key])
+
+
+# Configuration
+class ModConfig(Config):
+    """
+    Handles all guild configs.
+
+    Note:
+    This instance is not using cache. Value for both `._cache` and `defaults` would be empty dictionary.
+    """
+
+    cog: Moderation
+
+    def __init__(self, cog: Moderation, db: AsyncIOMotorCollection):
+        super().__init__(cog, db, defaults={}, use_cache=False)
+        self.__guild_configs: Set[GuildConfig] = set()
+
+    async def fetch(self, *args, **kwargs) -> Dict[str, Any]:
+        if not self.defaults:
+            # we're not using cache for this instance, this is just temporary populated
+            # to resolve default keys in fetched data.
+            # this must be done before calling super().fetch().
+            for guild in self.bot.guilds:
+                self.defaults[str(guild.id)] = self.deepcopy(_default_config)
+        data = await super().fetch(*args, **kwargs)
+        self.defaults.clear()
+        for guild in self.bot.guilds:
+            config = GuildConfig(self.cog, guild, data=data.pop(str(guild.id), {}))
+            self.__guild_configs.add(config)
+        return data  # just leftovers or empty dict
+
+    def get_config(self, guild: discord.Guild) -> GuildConfig:
+        """Returns config for the guild specified."""
+        config = next((c for c in self.__guild_configs if c.guild.id == guild.id), None)
+        if config is None:
+            config = GuildConfig(self.cog, guild, data={})
+            self.__guild_configs.add(config)
+        return config

--- a/moderation/core/logging.py
+++ b/moderation/core/logging.py
@@ -42,14 +42,14 @@ class ModerationLogging:
         """
         Returns `True` if logging is enabled for the specified guild.
         """
-        config = self.cog.guild_config(guild.id)
+        config = self.cog.config.get_config(guild)
         return config.get("logging", False)
 
     def is_whitelisted(self, guild: discord.Guild, channel: discord.TextChannel) -> bool:
         """
         Returns `True` if channel or its category is whitelisted.
         """
-        config = self.cog.guild_config(guild.id)
+        config = self.cog.config.get_config(guild)
         whitelist_ids = config.get("channel_whitelist", [])
         if str(channel.id) in whitelist_ids:
             return True
@@ -97,7 +97,7 @@ class ModerationLogging:
         send_params: Optional[Dict[str, Any]]
             Additional parameter to use when sending the log message.
         """
-        config = self.cog.guild_config(guild.id)
+        config = self.cog.config.get_config(guild)
         channel = config.log_channel
         if channel is None:
             return
@@ -170,7 +170,7 @@ class ModerationLogging:
         channel : discord.TextChannel
             The channel to get or create the webhook from.
         """
-        config = self.cog.guild_config(channel.guild.id)
+        config = self.cog.config.get_config(channel.guild)
         wh_url = config.get("webhook")
         if wh_url:
             wh = discord.Webhook.from_url(

--- a/moderation/info.json
+++ b/moderation/info.json
@@ -5,8 +5,8 @@
         "\n**Note:**\nYou will need the `MODERATOR` permission level in order to run any of these commands.",
         "\n**Version:**\n`{0}`"
     ],
-    "author": "Jerrie-Aries",
-    "version": "1.3.6",
+    "authors": ["Jerrie-Aries"],
+    "version": "1.3.7",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/rolemanager/core/config.py
+++ b/rolemanager/core/config.py
@@ -31,26 +31,13 @@ class RoleManagerConfig(Config):
     """
 
     def __init__(self, cog: RoleManager, db: AsyncIOMotorCollection):
-        super().__init__(cog, db, use_cache=False)
+        super().__init__(cog, db, defaults=_default_config, use_cache=False)
 
-    async def fetch(self) -> ConfigPayload:
-        data = await super().fetch()
-        if not data:
-            # empty dict returned from .fetch()
-            data = self.deepcopy(_default_config)
-        else:
-            data = self._resolve_keys(data)
-        return data
-
-    def _resolve_keys(self, data: Dict[str, Any]) -> ConfigPayload:
-        """
-        This is to prevent unnecessarily updating the database with default config on startup
-        mainly when first time loading this plugin.
-        """
-        keys = _default_config.keys()
-        for key in keys:
-            if key not in data:
-                data[key] = self.deepcopy(_default_config[key])
+    async def fetch(self, *args, **kwargs) -> ConfigPayload:
+        if not self.defaults:
+            self.defaults = self.deepcopy(_default_config)
+        data = await super().fetch(*args, **kwargs)
+        self.defaults.clear()
         return data
 
     async def update(self, *, data: Dict[str, Any] = None) -> None:

--- a/rolemanager/info.json
+++ b/rolemanager/info.json
@@ -9,8 +9,8 @@
         "\n**Note:**\nIn order for any of the features in this plugin to work, the bot must have `Manage Roles` permission on your server.",
         "\n**Version:**\n`{0}`"
     ],
-    "author": "Jerrie-Aries",
-    "version": "2.3.3",
+    "authors": ["Jerrie-Aries"],
+    "version": "2.3.4",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/supportutils/core/config.py
+++ b/supportutils/core/config.py
@@ -55,21 +55,6 @@ class SupportUtilityConfig(Config):
     def __init__(self, cog: SupportUtility, db: AsyncIOMotorCollection):
         super().__init__(cog, db, defaults=_default_config)
 
-    async def fetch(self) -> Dict[str, Any]:
-        await super().fetch()
-        self.recursively_resolve_keys(self.defaults, self._cache)
-
-    # TODO: if this works, implement this in utils
-    # then this can be removed
-    def recursively_resolve_keys(self, base: Dict[str, Any], data: Dict[str, Any]) -> None:
-        for key, value in base.items():
-            if key not in data:
-                data[key] = self.deepcopy(value)
-                continue
-            if isinstance(value, dict):
-                # go deeper
-                self.recursively_resolve_keys(value, data[key])
-
     @property
     def contact(self) -> Dict[str, Any]:
         return self["contact"]

--- a/supportutils/info.json
+++ b/supportutils/info.json
@@ -7,8 +7,8 @@
         "Link dropdown option to a specific category.",
         "\n**Version:**\n`{0}`"
     ],
-    "author": "Jerrie-Aries",
-    "version": "0.5.0",
+    "authors": ["Jerrie-Aries"],
+    "version": "0.5.1",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -63,7 +63,6 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         self.feedback_manager: FeedbackManager = FeedbackManager(self)
 
     async def cog_load(self) -> None:
-        await self.config.fetch()
         self.bot.loop.create_task(self.initialize())
 
     async def cog_unload(self) -> None:
@@ -75,6 +74,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
 
     async def initialize(self) -> None:
         await self.bot.wait_for_connected()
+        await self.config.fetch()
         await self.contact_manager.initialize()
         await self.feedback_manager.populate()
 


### PR DESCRIPTION
### Changelog

This PR updates plugins that use `Config` class from `utils` to be able to resolve default keys if missing. This solution has been implemented in `utils` [v1.3.1](https://github.com/Jerrie-Aries/modmail-plugins/commit/439e66483e11c2a9d67140f0f47a17fc2ecd0880).
- `invites` plugin v2.0.1
- `moderation` plugin v1.3.7
- `rolemanager` plugin v2.3.4
- `supportutils` plugin v1.5.1

The issue I was having was when adding new features that need new config options to the plugins. Most of the times, errors occured because of the config from database were not synchronized with the new ones. I had to make temporary migration script to resolve that.

Hopefully update in this PR will resolve those issues once and for all.