### PR TITLE
`moderation` plugin v1.4.0: Enable/disable certain logging events

### DIFF
--- a/moderation/core/config.py
+++ b/moderation/core/config.py
@@ -17,18 +17,38 @@ if TYPE_CHECKING:
 __all__ = ("GuildConfig", "ModConfig")
 
 
-_default_config = {
+_public_config = {
     "log_channel": str(int()),
     "logging": False,
     "webhook": None,
     "channel_whitelist": [],
 }
 
+_protected_config = {
+    "log_events": {
+        "member_update": True,
+        "member_remove": True,  # kick
+        "member_ban": True,
+        "member_unban": True,
+        "channel_create": True,
+        "channel_delete": True,
+        "message_delete": True,
+        "bulk_message_delete": True,
+        "message_edit": True,
+    },
+}
+
+
+_default_config = {**_public_config, **_protected_config}
+
 
 class GuildConfig(BaseConfig):
     """
     Config instance for a guild.
     """
+
+    public_keys = _public_config.keys()
+    protected_keys = _protected_config.keys()
 
     def __init__(self, cog: Moderation, guild: discord.Guild, data: Dict[str, Any]):
         super().__init__(cog, defaults=_default_config)

--- a/moderation/core/config.py
+++ b/moderation/core/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Set, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Set, TYPE_CHECKING
 
 import discord
 from discord.utils import MISSING
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 __all__ = ("GuildConfig", "ModConfig")
 
+
+# Note: If new config is added, make sure to update `?logging config` command.
 
 _public_config = {
     "log_channel": str(int()),

--- a/moderation/core/logging.py
+++ b/moderation/core/logging.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 
-from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, Optional, Union, TYPE_CHECKING
 
 import discord
 from discord.utils import MISSING
@@ -74,13 +74,7 @@ class ModerationLogging:
         self,
         *,
         action: str,
-        target: Optional[
-            Union[
-                discord.Member,
-                discord.User,
-                List[discord.Member],
-            ]
-        ] = None,
+        target: Optional[Any] = None,
         description: Optional[str] = None,
         moderator: Optional[discord.Member] = None,
         reason: Optional[str] = None,
@@ -94,10 +88,10 @@ class ModerationLogging:
         ----------
         action: str
             The moderation action.
-        target: discord.Member or discord.User or List
+        target: Optional[Any]
             Target that was executed from this moderation action.
-            Could be a list of "Member" or "User" especially if the action is "multiban".
-        description: str
+            This also could be a list of "Member" or "User" especially if the action is "multiban".
+        description: Optional[str]
             A message to be put in the Embed description.
         moderator: Optional[discord.Member]
             Moderator that executed this moderation action.
@@ -141,7 +135,8 @@ class ModerationLogging:
                 embed.set_thumbnail(url=target.display_avatar.url)
                 embed.add_field(name="User", value=target.mention)
                 embed.set_footer(text=f"User ID: {target.id}")
-            elif isinstance(target, list):
+            elif isinstance(target, list) and isinstance(target[0], (discord.Member, discord.User)):
+                # multiban
                 embed.add_field(
                     name="User" if len(target) == 1 else "Users",
                     value="\n".join(str(m) for m in target),
@@ -380,7 +375,7 @@ class ModerationLogging:
             if int(entry.target.id) == user.id:
                 break
         else:
-            logger.error("Cannot find the audit log entry for user ban of %d, guild %s.", user, guild)
+            logger.error("Cannot find the audit log entry for user ban of %d, guild %s.", user, self.guild)
             return
 
         mod = entry.user
@@ -405,7 +400,7 @@ class ModerationLogging:
             if int(entry.target.id) == user.id:
                 break
         else:
-            logger.error("Cannot find the audit log entry for user unban of %d, guild %s.", user, guild)
+            logger.error("Cannot find the audit log entry for user unban of %d, guild %s.", user, self.guild)
             return
 
         mod = entry.user
@@ -427,7 +422,7 @@ class ModerationLogging:
                 break
         else:
             logger.error(
-                "Cannot find the audit log entry for channel creation of %d, guild %s.", channel, guild
+                "Cannot find the audit log entry for channel creation of %d, guild %s.", channel, self.guild
             )
             return
 
@@ -453,7 +448,7 @@ class ModerationLogging:
                 break
         else:
             logger.error(
-                "Cannot find the audit log entry for channel deletion of %d, guild %s.", channel, guild
+                "Cannot find the audit log entry for channel deletion of %d, guild %s.", channel, self.guild
             )
             return
 

--- a/moderation/core/logging.py
+++ b/moderation/core/logging.py
@@ -226,9 +226,6 @@ class ModerationLogging:
         - Timed out changes
         - Role updates
         """
-        if not self.is_enabled():
-            return
-
         if before.guild_avatar != after.guild_avatar:
             return await self._on_member_guild_avatar_update(before, after)
 
@@ -355,10 +352,7 @@ class ModerationLogging:
         For some reason Discord and discord.py do not dispatch or have a specific event when a guild member
         was kicked, so we have to do it manually here.
         """
-        if not self.is_enabled():
-            return
-
-        audit_logs = member.guild.audit_logs(limit=10, action=discord.AuditLogAction.kick)
+        audit_logs = self.guild.audit_logs(limit=10, action=discord.AuditLogAction.kick)
         async for entry in audit_logs:
             if int(entry.target.id) == member.id:
                 break
@@ -380,11 +374,8 @@ class ModerationLogging:
             description=f"`{member}` has been kicked.",
         )
 
-    async def on_member_ban(self, guild: discord.Guild, user: Union[discord.User, discord.Member]) -> None:
-        if not self.is_enabled():
-            return
-
-        audit_logs = guild.audit_logs(limit=10, action=discord.AuditLogAction.ban)
+    async def on_member_ban(self, user: Union[discord.User, discord.Member]) -> None:
+        audit_logs = self.guild.audit_logs(limit=10, action=discord.AuditLogAction.ban)
         async for entry in audit_logs:
             if int(entry.target.id) == user.id:
                 break
@@ -408,11 +399,8 @@ class ModerationLogging:
             description=f"`{user}` has been banned.",
         )
 
-    async def on_member_unban(self, guild: discord.Guild, user: discord.User) -> None:
-        if not self.is_enabled():
-            return
-
-        audit_logs = guild.audit_logs(limit=10, action=discord.AuditLogAction.unban)
+    async def on_member_unban(self, user: discord.User) -> None:
+        audit_logs = self.guild.audit_logs(limit=10, action=discord.AuditLogAction.unban)
         async for entry in audit_logs:
             if int(entry.target.id) == user.id:
                 break
@@ -433,10 +421,7 @@ class ModerationLogging:
         )
 
     async def on_guild_channel_create(self, channel: discord.abc.GuildChannel) -> None:
-        if not self.is_enabled():
-            return
-
-        audit_logs = channel.guild.audit_logs(limit=10, action=discord.AuditLogAction.channel_create)
+        audit_logs = self.guild.audit_logs(limit=10, action=discord.AuditLogAction.channel_create)
         async for entry in audit_logs:
             if int(entry.target.id) == channel.id:
                 break
@@ -462,10 +447,7 @@ class ModerationLogging:
         )
 
     async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel) -> None:
-        if not self.is_enabled():
-            return
-
-        audit_logs = channel.guild.audit_logs(limit=10, action=discord.AuditLogAction.channel_delete)
+        audit_logs = self.guild.audit_logs(limit=10, action=discord.AuditLogAction.channel_delete)
         async for entry in audit_logs:
             if int(entry.target.id) == channel.id:
                 break
@@ -490,7 +472,7 @@ class ModerationLogging:
             **kwargs,
         )
 
-    async def _on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
+    async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
         channel = self.guild.get_channel(payload.channel_id)
         if channel is None or self.is_whitelisted(channel):
             return
@@ -528,7 +510,7 @@ class ModerationLogging:
             embed=embed,
         )
 
-    async def _on_raw_bulk_message_delete(self, payload: discord.RawBulkMessageDeleteEvent) -> None:
+    async def on_raw_bulk_message_delete(self, payload: discord.RawBulkMessageDeleteEvent) -> None:
         channel = self.guild.get_channel(payload.channel_id)
         if channel is None or self.is_whitelisted(channel):
             return
@@ -572,7 +554,7 @@ class ModerationLogging:
             send_params=send_params,
         )
 
-    async def _on_raw_message_edit(self, payload: discord.RawMessageUpdateEvent) -> None:
+    async def on_raw_message_edit(self, payload: discord.RawMessageUpdateEvent) -> None:
         channel = self.guild.get_channel(payload.channel_id)
         if channel is None or self.is_whitelisted(channel):
             return

--- a/moderation/core/views.py
+++ b/moderation/core/views.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, TYPE_CHECKING
+
+import discord
+
+from discord import ui, Interaction
+from discord.ext.modmail_utils.ui import View
+from discord.utils import MISSING
+
+
+if TYPE_CHECKING:
+    from bot import ModmailBot
+    from ..moderation import Moderation
+    from .logging import ModerationLogging
+
+    Callback = Callable[..., Awaitable]
+
+
+class Select(ui.Select):
+    def __init__(self, *args: Any, **kwargs: Any):
+        self._select_callback = kwargs.pop("callback", MISSING)
+        super().__init__(*args, **kwargs)
+
+    async def callback(self, interaction: Interaction) -> None:
+        assert self.view is not None
+        await self._select_callback(interaction, self)
+
+
+class LoggingView(View):
+    def __init__(self, user: discord.Member, cog: Moderation, glogger: ModerationLogging):
+        self.user: discord.Member = user
+        self.cog: Moderation = cog
+        self.bot: ModmailBot = cog.bot
+        self.logger: ModerationLogging = glogger
+        super().__init__(timeout=300)
+        self._embed: discord.Embed = MISSING
+
+    def fill_items(self) -> None:
+        options = []
+        for key, val in self.logger.config["log_events"].items():
+            option = discord.SelectOption(
+                label=" ".join(key.split("_")).capitalize(),
+                value=key,
+                default=val,
+            )
+            options.append(option)
+        select = Select(
+            options=options,
+            placeholder="Choose features to enable",
+            min_values=0,
+            max_values=len(options),
+            callback=self._select_callback,
+        )
+        self.add_item(select)
+
+    @property
+    def embed(self) -> discord.Embed:
+        if self._embed is MISSING:
+            embed = discord.Embed(
+                title="Logging events",
+                description=self.output_description,
+                color=self.bot.main_color,
+            )
+            embed.set_author(name=self.bot.user.name, icon_url=self.bot.user.display_avatar)
+            self._embed = embed
+        return self._embed
+
+    @property
+    def output_description(self) -> str:
+        description = ""
+        for key, val in self.logger.config["log_events"].items():
+            value = "\N{WHITE HEAVY CHECK MARK}" if val else "\N{CROSS MARK}"
+            description += f'- {" ".join(key.split("_")).capitalize()}' + f" -> {value}\n"
+        return description
+
+    async def _select_callback(self, interaction: Interaction, select: Select) -> None:
+        embed = self.message.embeds[0]
+        for key in self.logger.config["log_events"].keys():
+            self.logger.config["log_events"][key] = key in select.values
+        embed.description = self.output_description
+        await interaction.response.edit_message(embed=embed, view=None)
+        self.value = True
+        self.stop()
+
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        if self.user.id == interaction.user.id:
+            return True
+        return False
+
+    async def on_timeout(self) -> None:
+        self.stop()
+        for child in self.children:
+            child.disabled = True
+        await self.message.edit(view=self)

--- a/moderation/core/views.py
+++ b/moderation/core/views.py
@@ -4,8 +4,8 @@ from typing import Any, Awaitable, Callable, TYPE_CHECKING
 
 import discord
 
-from discord import ui, Interaction
-from discord.ext.modmail_utils.ui import View
+from discord import ui, ButtonStyle, Interaction
+from discord.ext.modmail_utils import ui as muui
 from discord.utils import MISSING
 
 
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
     from .logging import ModerationLogging
 
     Callback = Callable[..., Awaitable]
+
+
+_check_mark = "\N{WHITE HEAVY CHECK MARK}"
+_cross_mark = "\N{CROSS MARK}"
 
 
 class Select(ui.Select):
@@ -27,16 +31,121 @@ class Select(ui.Select):
         await self._select_callback(interaction, self)
 
 
-class LoggingView(View):
-    def __init__(self, user: discord.Member, cog: Moderation, glogger: ModerationLogging):
+class EphemeralView(muui.View):
+    def __init__(self, handler: LoggingPanelView, *args: Any, timeout: int = 120, **kwargs: Any):
+        self.handler: LoggingPanelView = handler
+        super().__init__(*args, **kwargs)
+
+
+class LoggingPanelView(muui.View):
+    def __init__(self, user: discord.Member, cog: Moderation, logger: ModerationLogging):
         self.user: discord.Member = user
         self.cog: Moderation = cog
         self.bot: ModmailBot = cog.bot
-        self.logger: ModerationLogging = glogger
+        self.logger: ModerationLogging = logger
+        self.guild: discord.Guild = logger.guild
         super().__init__(timeout=300)
-        self._embed: discord.Embed = MISSING
+        self._resolve_components()
 
-    def fill_items(self) -> None:
+    def _resolve_components(self) -> None:
+        enabled = self.logger.config["logging"]
+        self.enable_button.label = "Disable" if enabled else "Enable"
+        if self.value:
+            self.close_button.label = "Done"
+            self.close_button.style = ButtonStyle.green
+
+    async def edit_message(self, *args: Any, **kwargs: Any) -> None:
+        self._resolve_components()
+        await super().edit_message(*args, **kwargs)
+
+    async def lock(self) -> None:
+        for child in self.children:
+            child.disabled = True
+        await self.edit_message()
+
+    async def unlock(self) -> None:
+        for child in self.children:
+            child.disabled = False
+        await self.edit_message()
+
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        if self.user.id == interaction.user.id:
+            return True
+        return False
+
+    @property
+    def embed(self) -> discord.Embed:
+        if self.message:
+            return self.message.embeds[0]
+        embed = discord.Embed(
+            title="Logging Config",
+            description=("Moderation logging configuration."),
+            color=self.bot.main_color,
+        )
+        embed.set_thumbnail(url=self.guild.icon)
+        embed.set_author(name=self.bot.user.name, url=self.bot.user.display_avatar)
+        embed.set_footer(text="Use buttons below to change the value.")
+
+        config = self.logger.config
+        embed.add_field(name="Enabled", value=f"`{config['logging']}`")
+        log_channel = config.log_channel
+        embed.add_field(name="Log channel", value=log_channel.mention if log_channel else "`None`")
+        webhook = config["webhook"]
+        embed.add_field(name="Webhook", value=f"[Webhook URL]({webhook })" if webhook else "`None`")
+        wl_channels = config["channel_whitelist"]
+        fmt_string = ""
+        for c in wl_channels:
+            fmt_string += f"<#{c}>\n"
+        embed.add_field(name="Whitelist channels", value=fmt_string if fmt_string else "`None`")
+        value = ""
+        for key, val in config["log_events"].items():
+            enabled = _check_mark if val else _cross_mark
+            value += f'- {" ".join(key.split("_")).capitalize()}' + f" -> {enabled}\n"
+        embed.add_field(name="Events", value=value, inline=False)
+        return embed
+
+    def update_embed_field(self, name: str, value: str, inline: bool = True) -> discord.Embed:
+        embed = self.embed
+        for i, field in enumerate(embed.fields):
+            if field.name == name:
+                embed.set_field_at(i, name=name, value=value, inline=inline)
+        return embed
+
+    def log_events_fmt_string(self) -> None:
+        value = ""
+        for key, val in self.logger.config["log_events"].items():
+            enabled = _check_mark if val else _cross_mark
+            value += f'- {" ".join(key.split("_")).capitalize()}' + f" -> {enabled}\n"
+        return value
+
+    @discord.ui.button(label="Enable", style=ButtonStyle.grey)
+    async def enable_button(self, interaction: Interaction, button: discord.ui.Button):
+        old_val = self.logger.config["logging"]
+        self.logger.config["logging"] = not old_val
+        self.value = True
+        self._resolve_components()
+        embed = self.update_embed_field("Enabled", f"`{self.logger.config['logging']}`")
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="Log channel", style=ButtonStyle.grey)
+    async def log_channel_button(self, interaction: Interaction, button: discord.ui.Button):
+        payload = {
+            "label": "Log channel",
+            "max_length": 100,
+            "required": True,
+            "default": self.logger.config["log_channel"],
+        }
+        modal = muui.Modal(
+            self,
+            {"log_channel": payload},
+            callback=self._channel_modal_submit,
+            title="Log channel",
+        )
+        await interaction.response.send_modal(modal)
+
+    @discord.ui.button(label="Log events", style=ButtonStyle.grey)
+    async def log_events_button(self, interaction: Interaction, button: discord.ui.Button):
+        view = EphemeralView(self, timeout=self.timeout)
         options = []
         for key, val in self.logger.config["log_events"].items():
             option = discord.SelectOption(
@@ -52,44 +161,121 @@ class LoggingView(View):
             max_values=len(options),
             callback=self._select_callback,
         )
-        self.add_item(select)
+        view.add_item(select)
+        await self.lock()
+        await interaction.response.send_message(view=view)
+        await view.wait()
+        await interaction.delete_original_response()
+        await self.unlock()
+        if not view.value:
+            # nothing changed
+            return
+        embed = self.update_embed_field("Events", self.log_events_fmt_string(), False)
+        await self.edit_message(embed=embed)
 
-    @property
-    def embed(self) -> discord.Embed:
-        if self._embed is MISSING:
-            embed = discord.Embed(
-                title="Logging events",
-                description=self.output_description,
-                color=self.bot.main_color,
+    @discord.ui.button(label="Whitelist", style=ButtonStyle.grey)
+    async def whitelist_button(self, interaction: Interaction, button: discord.ui.Button):
+        button_args = [
+            ("Add", self._add_whitelist),
+            ("Clear", self._clear_whitelist),
+            ("Close", self._close_ephemeral),
+        ]
+        view = EphemeralView(self, timeout=self.timeout)
+        for arg in button_args:
+            button = muui.Button(
+                label=arg[0],
+                callback=arg[1],
+                style=ButtonStyle.grey if arg[0] != "Close" else ButtonStyle.red,
             )
-            embed.set_author(name=self.bot.user.name, icon_url=self.bot.user.display_avatar)
-            self._embed = embed
-        return self._embed
+            view.add_item(button)
+        await self.lock()
+        await interaction.response.send_message(view=view)
+        await view.wait()
+        await interaction.delete_original_response()
+        await self.unlock()
 
-    @property
-    def output_description(self) -> str:
-        description = ""
-        for key, val in self.logger.config["log_events"].items():
-            value = "\N{WHITE HEAVY CHECK MARK}" if val else "\N{CROSS MARK}"
-            description += f'- {" ".join(key.split("_")).capitalize()}' + f" -> {value}\n"
-        return description
-
-    async def _select_callback(self, interaction: Interaction, select: Select) -> None:
-        embed = self.message.embeds[0]
-        for key in self.logger.config["log_events"].keys():
-            self.logger.config["log_events"][key] = key in select.values
-        embed.description = self.output_description
-        await interaction.response.edit_message(embed=embed, view=None)
-        self.value = True
-        self.stop()
-
-    async def interaction_check(self, interaction: Interaction) -> bool:
-        if self.user.id == interaction.user.id:
-            return True
-        return False
-
-    async def on_timeout(self) -> None:
-        self.stop()
+    @discord.ui.button(label="Close", style=ButtonStyle.red, row=1)
+    async def close_button(self, interaction: Interaction, button: discord.ui.Button):
+        self.interaction = interaction
+        self.value = False
         for child in self.children:
             child.disabled = True
-        await self.message.edit(view=self)
+        self.stop()
+        await interaction.response.edit_message(view=self)
+
+    async def _add_whitelist(self, interaction: Interaction, button: muui.Button) -> None:
+        payload = {
+            "label": "Channel",
+            "max_length": 100,
+            "required": True,
+        }
+        modal = muui.Modal(
+            self,
+            {"channel_whitelist": payload},
+            callback=self._channel_modal_submit,
+            title="Whitelist channels",
+        )
+        await interaction.response.send_modal(modal)
+
+    async def _clear_whitelist(self, interaction: Interaction, button: muui.Button) -> None:
+        wl_channels = self.logger.config["channel_whitelist"]
+        if not wl_channels:
+            await interaction.response.send_message("There is no whitelist channel.")
+        else:
+            wl_channels.clear()
+            await interaction.response.defer()
+            self.value = True
+            embed = self.update_embed_field("Whitelist channels", "`None`")
+            await self.edit_message(embed=embed)
+
+    async def _close_ephemeral(self, interaction: Interaction, button: muui.Button) -> None:
+        view = button.view
+        await interaction.response.defer()
+        view.stop()
+
+    async def _select_callback(self, interaction: Interaction, select: Select) -> None:
+        view = select.view
+        for key in self.logger.config["log_events"].keys():
+            old_val = self.logger.config["log_events"][key]
+            if (old_val and key in select.values) or (not old_val and key not in select.values):
+                continue
+            self.logger.config["log_events"][key] = key in select.values
+            view.value = True
+            view.handler.value = True
+        await interaction.response.defer()
+        view.stop()
+
+    async def _channel_modal_submit(self, interaction: Interaction, modal: muui.Modal) -> None:
+        modal.stop()
+        child = modal.children[0]  # we only have one element
+        err_embed = discord.Embed(title="Error", color=self.bot.error_color)
+        try:
+            value = int(child.value)
+        except (TypeError, ValueError):
+            err_embed.description = "Invalid input type. The input must be integers for channel ID."
+            return await interaction.response.send_message(embed=err_embed, ephemeral=True)
+
+        channel = self.guild.get_channel(value)
+        if channel is None:
+            err_embed.description = f"Channel `{value}` not found."
+            return await interaction.response.send_message(embed=err_embed, ephemeral=True)
+        if child.name == "log_channel":
+            self.logger.config[child.name] = str(channel.id)
+            self.value = True
+            embed = self.update_embed_field(modal.title, f"<#{channel.id}>")
+        elif child.name == "channel_whitelist":
+            # whitelist channel
+            wl_channels = self.logger.config["channel_whitelist"]
+            if str(channel.id) in wl_channels:
+                err_embed.description = f"Channel {channel.mention} is already whitelisted."
+                return await interaction.response.send_message(embed=err_embed, ephemeral=True)
+            wl_channels.append(str(channel.id))
+            self.value = True
+            fmt_string = ""
+            for c in wl_channels:
+                fmt_string += f"<#{c}>\n"
+            embed = self.update_embed_field(modal.title, fmt_string)
+        else:
+            raise TypeError(f"Invalid modal input session, `{child.name}`.")
+        await interaction.response.defer()
+        await self.edit_message(embed=embed)

--- a/moderation/info.json
+++ b/moderation/info.json
@@ -6,7 +6,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "authors": ["Jerrie-Aries"],
-    "version": "1.3.7",
+    "version": "1.4.0",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/moderation/moderation.py
+++ b/moderation/moderation.py
@@ -165,29 +165,30 @@ class Moderation(commands.Cog):
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def logging_group(self, ctx: commands.Context):
         """
-        Logging feature for Moderation actions.
+        Logging feature for Moderation actions/events.
 
-        __**Support actions:**__
+        You can also enable or disable which events to be logged.
+
+        __**Support actions/events:**__
         - `ban`/`unban`
         - `kick`
         - Timeout, `mute`/`unmute`
         - Member roles update, `add`/`remove`
         - Nickname changes, `set`/`update`/`remove`
-        - Channels, `created`/`deleted`
-        - Message updates, `deleted`/`edited`
+        - Channels, `create`/`delete`
+        - Message updates, `delete`/`edit`
 
         For initial setup, set the logging channel and enable the logging.
-        Use commands:
-        - `{prefix}logging config channel #channel`
-        - `{prefix}logging config enable true`
+        To initiate logging config panel, use command:
+        - `{prefix}logging config`
         """
         await ctx.send_help(ctx.command)
 
-    @logging_group.group(name="config", usage="<command> [argument]", invoke_without_command=True)
+    @logging_group.group(name="config", invoke_without_command=True)
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def logging_config(self, ctx: commands.Context):
         """
-        Moderation logging configuration panel.
+        Moderation logging config panel with interactive buttons.
         """
         config = self.config.get_config(ctx.guild)
         view = LoggingPanelView(ctx.author, self, self.get_logger(ctx.guild))

--- a/moderation/moderation.py
+++ b/moderation/moderation.py
@@ -509,7 +509,7 @@ class Moderation(commands.Cog):
         )
 
     # Purge commands
-    @commands.group(aliases=["clear"], invoke_without_command=True)
+    @commands.group(invoke_without_command=True)
     @checks.has_permissions(PermissionLevel.MODERATOR)
     async def purge(self, ctx: commands.Context, amount: int):
         """


### PR DESCRIPTION
### Changelog

__Changed__
`?logging config` now will initiate configuration panel embed with buttons. The embed will show all config values and logging events with their current enabled or disabled status. The values can be edited using those buttons.

__Removed__
- `?logging config enable`
- `?logging config channel`
- `?logging config whitelist` and its subcommands.

__Internal__
`ModerationLogging` instance now only handles logging for a guild.

This PR implements the feature request #36 .