### PR TITLE
`embedmanager` plugin v1.4.0

### DIFF
--- a/embedmanager/core/data.py
+++ b/embedmanager/core/data.py
@@ -32,6 +32,12 @@ DESCRIPTIONS = {
         "  - `0x<hex>`\n  - `#<hex>`\n  - `0x#<hex>`\n  - `rgb(<number>, <number>, <number>)`",
         "Like CSS, `<number>` can be either 0-255 or 0-100% and `<hex>` can be either a 6 digit hex number or a 3 digit hex shortcut (e.g. #fff).\n",
     ],
+    "timestamp": [
+        "**Timestamp:**",
+        "The timestamp must be in a format of Unix Timestamp or [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html).",
+        "Use the Epoch Unix Timestamp [converter](https://www.unixtimestamp.com/) to quickly generate a timestamp.\n",
+        "If you want the timestamp to be the current date and time, just type `now` or `0` in the text input.",
+    ],
     "fields": [
         "**Fields:**",
         f"- `Name`: Name of the field. Can be up to {Limit.embed_field_name} characters.",
@@ -48,6 +54,7 @@ SHORT_DESCRIPTIONS = {
     "body": "Description, thumbnail and image URLs.",
     "footer": "The footer text and/or icon of the embed.",
     "color": "Embed's color.",
+    "timestamp": "The timestamp shown at the bottom right of the embed.",
     "fields": "Add or remove fields.",
 }
 
@@ -116,6 +123,13 @@ INPUT_DATA: Dict[str, Any] = {
         },
         "icon_url": {
             "label": "Icon URL",
+            "max_length": _short_length,
+            "required": False,
+        },
+    },
+    "timestamp": {
+        "timestamp": {
+            "label": "Timestamp",
             "max_length": _short_length,
             "required": False,
         },

--- a/embedmanager/core/data.py
+++ b/embedmanager/core/data.py
@@ -28,9 +28,8 @@ DESCRIPTIONS = {
     ],
     "color": [
         "**Color:**",
-        "- `Value`: Color code of the embed.",
-        "The following formats are accepted:",
-        "\t- `0x<hex>`\n\t- `#<hex>`\n\t- `0x#<hex>`\n\t- `rgb(<number>, <number>, <number>)`",
+        "- `Value`: Color code of the embed. The following formats are accepted:",
+        "  - `0x<hex>`\n  - `#<hex>`\n  - `0x#<hex>`\n  - `rgb(<number>, <number>, <number>)`",
         "Like CSS, `<number>` can be either 0-255 or 0-100% and `<hex>` can be either a 6 digit hex number or a 3 digit hex shortcut (e.g. #fff).\n",
     ],
     "fields": [

--- a/embedmanager/core/data.py
+++ b/embedmanager/core/data.py
@@ -40,10 +40,6 @@ DESCRIPTIONS = {
         "Click `Add Field` to add a new field, or `Clear Fields` to clear all fields, if any.",
         f"Embed fields can be added up to {Limit.embed_fields}.\n",
     ],
-    "note": [
-        "__**Notes:**__",
-        f"- The combine sum of characters in embeds in a single message must not exceed {Limit.embed} characters.\n",
-    ],
 }
 
 SHORT_DESCRIPTIONS = {
@@ -53,6 +49,12 @@ SHORT_DESCRIPTIONS = {
     "footer": "The footer text and/or icon of the embed.",
     "color": "Embed's color.",
     "fields": "Add or remove fields.",
+}
+
+FOOTER_TEXTS = {
+    "note": [
+        f"Note: The combine sum of characters in embeds in a single message must not exceed {Limit.embed} characters.\n",
+    ]
 }
 
 INPUT_DATA: Dict[str, Any] = {

--- a/embedmanager/core/models.py
+++ b/embedmanager/core/models.py
@@ -10,22 +10,14 @@ from .data import INPUT_DATA
 
 
 if TYPE_CHECKING:
-    from bot import ModmailBot
     from ..embedmanager import EmbedManager
 
 
 class EmbedEditor:
-    def __init__(
-        self,
-        cog: EmbedManager,
-        embeds: List[discord.Embed] = MISSING,
-        *,
-        index: int = MISSING,
-    ):
+    def __init__(self, cog: EmbedManager, embeds: List[discord.Embed] = MISSING):
         self.cog: EmbedManager = cog
-        self.bot: ModmailBot = cog.bot
         self.embeds: List[discord.Embed] = embeds if embeds is not MISSING else [discord.Embed()]
-        self.index: int = index if index is not MISSING else 0
+        self.index: int = 0
         self._inputs: Dict[str, Any] = {}
 
     def __getitem__(self, key: str) -> Any:

--- a/embedmanager/core/models.py
+++ b/embedmanager/core/models.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, List, TYPE_CHECKING
+
+import discord
+
+from discord.utils import MISSING
+
+from .data import INPUT_DATA
+
+
+if TYPE_CHECKING:
+    from bot import ModmailBot
+    from ..embedmanager import EmbedManager
+
+
+class EmbedEditor:
+    def __init__(
+        self,
+        cog: EmbedManager,
+        embeds: List[discord.Embed] = MISSING,
+        *,
+        index: int = MISSING,
+    ):
+        self.cog: EmbedManager = cog
+        self.bot: ModmailBot = cog.bot
+        self.embeds: List[discord.Embed] = embeds if embeds is not MISSING else [discord.Embed()]
+        self.index: int = index if index is not MISSING else 0
+        self._inputs: Dict[str, Any] = {}
+
+    def __getitem__(self, key: str) -> Any:
+        if str(self.index) not in self._inputs:
+            self._populate_default_inputs()
+        return self._inputs[str(self.index)][key]
+
+    def _populate_default_inputs(self) -> None:
+        payload = {}
+        for key, val in list(INPUT_DATA.items()):
+            payload[key] = {}
+            for k, _ in list(val.items()):
+                payload[key][k] = {}
+        self._inputs[str(self.index)] = payload
+
+    @property
+    def embed(self) -> discord.Embed:
+        return self.embeds[self.index]
+
+    def add(self, embed: Optional[discord.Embed] = None) -> None:
+        if embed is None:
+            embed = discord.Embed()
+        self.embeds.append(embed)
+
+    def update(self, *, data: Dict[str, Any], category: str) -> discord.Embed:
+        """
+        Update embed from the response data.
+        """
+        embed = self.embed
+        if category == "title":
+            title = data["title"]
+            embed.title = title
+            if title:
+                url = data["url"]
+            else:
+                url = None
+            embed.url = url
+        if category == "author":
+            embed.set_author(**data)
+        if category == "body":
+            embed.description = data["description"]
+            thumbnail_url = data["thumbnail"]
+            if thumbnail_url:
+                embed.set_thumbnail(url=thumbnail_url)
+            image_url = data["image"]
+            if image_url:
+                embed.set_image(url=image_url)
+        if category == "color":
+            embed.colour = data["value"]
+        if category == "footer":
+            embed.set_footer(**data)
+        if category == "fields":
+            embed.add_field(**data)
+        embed.timestamp = discord.utils.utcnow()
+        return embed

--- a/embedmanager/core/views.py
+++ b/embedmanager/core/views.py
@@ -199,8 +199,10 @@ class EmbedBuilderView(muui.View):
     @ui.button(label="Done", style=ButtonStyle.green)
     async def _action_done(self, *args: Any) -> None:
         interaction, _ = args
+        await interaction.response.defer()
+        await interaction.delete_original_response()
+        self.value = True
         self.disable_and_stop()
-        await interaction.response.edit_message(view=self)
 
     @ui.button(label="New", style=ButtonStyle.blurple)
     async def _action_new(self, *args: Any) -> None:

--- a/embedmanager/core/views.py
+++ b/embedmanager/core/views.py
@@ -11,7 +11,7 @@ from discord.utils import MISSING
 from discord.ext.modmail_utils import ui as muui
 from yarl import URL
 
-from .data import DESCRIPTIONS, SHORT_DESCRIPTIONS, INPUT_DATA
+from .data import DESCRIPTIONS, FOOTER_TEXTS, SHORT_DESCRIPTIONS, INPUT_DATA
 
 
 if TYPE_CHECKING:
@@ -98,7 +98,7 @@ class EmbedBuilderView(muui.View):
     children: List[muui.Button]
 
     def __init__(
-        self, cog: EmbedManager, user: discord.Member, *, timeout: float = 600.0, add_items: bool = True
+        self, cog: EmbedManager, user: discord.Member, *, timeout: float = 300.0, add_items: bool = True
     ):
         super().__init__(extras=deepcopy(INPUT_DATA), timeout=timeout)
         self.bot: ModmailBot = cog.bot
@@ -151,7 +151,9 @@ class EmbedBuilderView(muui.View):
         for opt in select.options:
             opt.default = opt.value == value
         embed = self.message.embeds[0]
-        embed.description = "\n".join(DESCRIPTIONS[value]) + "\n\n" + "\n".join(DESCRIPTIONS["note"])
+        embed.description = "\n".join(DESCRIPTIONS[value])
+        if not embed.footer:
+            embed.set_footer(text="\n".join(FOOTER_TEXTS["note"]))
         await self.update_view(interaction)
 
     @ui.button(label="Done", style=ButtonStyle.green)

--- a/embedmanager/core/views.py
+++ b/embedmanager/core/views.py
@@ -112,6 +112,7 @@ class EmbedBuilderView(muui.View):
             self.refresh()
 
     def _populate_select_options(self) -> None:
+        self._category_select.options.clear()
         for key in self.extras:
             option = discord.SelectOption(
                 label=key.title(),
@@ -144,7 +145,7 @@ class EmbedBuilderView(muui.View):
             func = self.message.edit
         await func(embed=self.message.embeds[0], view=self)
 
-    @ui.select(placeholder="Select a category", options=[], row=0)
+    @ui.select(placeholder="Select a category", row=0)
     async def _category_select(self, interaction: Interaction, select: ui.Select) -> None:
         self.current = value = select.values[0]
         for opt in select.options:

--- a/embedmanager/core/views.py
+++ b/embedmanager/core/views.py
@@ -61,7 +61,7 @@ def _resolve_conversion(key: str, sub_key: str, value: str) -> Any:
 class Select(ui.Select):
     def __init__(self, *, options: List[discord.SelectOption], **kwargs):
         super().__init__(
-            placeholder=kwargs.pop("placeholder") or "Select a category",
+            placeholder=kwargs.pop("placeholder", None) or "Select a category",
             min_values=1,
             max_values=1,
             options=options,
@@ -103,17 +103,15 @@ class EmbedBuilderView(muui.View):
 
     def _add_menu(self) -> None:
         options = []
-        placeholder = None
         for key in self.extras:
-            if key == self.current:
-                placeholder = key.title()
             option = discord.SelectOption(
                 label=key.title(),
                 description=SHORT_DESCRIPTIONS[key],
                 value=key,
+                default=key == self.current,
             )
             options.append(option)
-        self.add_item(Select(options=options, row=0, placeholder=placeholder))
+        self.add_item(Select(options=options, row=0))
 
     def _generate_buttons(self) -> None:
         if self.current == "fields":
@@ -168,10 +166,7 @@ class EmbedBuilderView(muui.View):
         await func(embed=self.message.embeds[0], view=self)
 
     async def on_dropdown_select(self, interaction: Interaction, select: Select) -> None:
-        value = select.values[0]
-        option = select.get_option(value)
-        select.placeholder = option.label
-        self.current = value
+        self.current = value = select.values[0]
         embed = self.message.embeds[0]
         embed.description = "\n".join(DESCRIPTIONS[value]) + "\n\n" + "\n".join(DESCRIPTIONS["note"])
         self.clear_items()

--- a/embedmanager/embedmanager.py
+++ b/embedmanager/embedmanager.py
@@ -158,8 +158,8 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         view = EmbedBuilderView(self, ctx.author)
         view.message = await ctx.send(embed=embed, view=view)
         await view.wait()
-        if view.embed:
-            await ctx.send(embed=view.embed)
+        if view.editor.embeds:
+            await ctx.send(embeds=view.editor.embeds)
 
     @embed_group.command(name="simple")
     @checks.has_permissions(PermissionLevel.MODERATOR)
@@ -247,8 +247,8 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         __**Note:**__
         If the message has multiple embeds, you can pass a number to `index` to specify which embed.
         """
-        source_embed = await self.get_embed_from_message(message, index)
-        view = EmbedBuilderView.from_embed(self, ctx.author, embed=source_embed)
+        await self.get_embed_from_message(message, index)
+        view = EmbedBuilderView.from_embed(self, ctx.author, embeds=message.embeds, index=index)
         description = "Select the category and press the button below respectively to start creating/editing your embed."
         embed = discord.Embed(
             title="Embed Editor",
@@ -259,8 +259,8 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         view.message = await ctx.send(embed=embed, view=view)
         await view.wait()
 
-        if view.embed:
-            await message.edit(embed=view.embed)
+        if view.editor.embeds:
+            await message.edit(embeds=view.editor.embeds)
             await ctx.message.add_reaction(YES_EMOJI)
 
     @embed_edit.command(name="json", aliases=["fromjson", "fromdata"])

--- a/embedmanager/embedmanager.py
+++ b/embedmanager/embedmanager.py
@@ -158,8 +158,9 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         view = EmbedBuilderView(self, ctx.author)
         view.message = await ctx.send(embed=embed, view=view)
         await view.wait()
-        if view.editor.embeds:
+        if view.value:
             await ctx.send(embeds=view.editor.embeds)
+            await ctx.message.add_reaction(YES_EMOJI)
 
     @embed_group.command(name="simple")
     @checks.has_permissions(PermissionLevel.MODERATOR)
@@ -262,9 +263,8 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         )
         view.message = await ctx.send(embed=embed, view=view)
         await view.wait()
-
-        if view.editor.embeds:
-            await message.edit(embeds=view.editor.embeds)
+        if view.value:
+            await ctx.send(embeds=view.editor.embeds)
             await ctx.message.add_reaction(YES_EMOJI)
 
     @embed_edit.command(name="json", aliases=["fromjson", "fromdata"])

--- a/embedmanager/embedmanager.py
+++ b/embedmanager/embedmanager.py
@@ -239,7 +239,7 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.MODERATOR)
     async def embed_edit(self, ctx: commands.Context, message: BotMessage, index: int = 0):
         """
-        Edit a message's embed sent by the bot.
+        Edit message's embeds sent by the bot.
         This will initiate the Embed Editor panel with interactive buttons and text inputs session.
         The values for the input fields are pre-defined based on the source embed.
 
@@ -264,7 +264,7 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         view.message = await ctx.send(embed=embed, view=view)
         await view.wait()
         if view.value:
-            await ctx.send(embeds=view.editor.embeds)
+            await message.edit(embeds=view.editor.embeds)
             await ctx.message.add_reaction(YES_EMOJI)
 
     @embed_edit.command(name="json", aliases=["fromjson", "fromdata"])

--- a/embedmanager/embedmanager.py
+++ b/embedmanager/embedmanager.py
@@ -253,7 +253,7 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
             raise commands.BadArgument(
                 f"Index `{index}` is out of range. Expected `0` to `{len(message.embeds) - 1}`."
             )
-        view = EmbedBuilderView.from_embed(self, ctx.author, embeds=message.embeds, index=index)
+        view = EmbedBuilderView.from_embeds(self, ctx.author, embeds=message.embeds, index=index)
         description = "Select the category and press the button below respectively to start creating/editing your embed."
         embed = discord.Embed(
             title="Embed Editor",

--- a/embedmanager/embedmanager.py
+++ b/embedmanager/embedmanager.py
@@ -95,7 +95,7 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         embeds = message.embeds
         if not embeds:
             raise commands.BadArgument("That message has no embeds.")
-        index = max(min(index, len(embeds)), 0)
+        index = max(min(index, len(embeds) - 1), 0)
         embed = message.embeds[index]
         if embed.type == "rich":
             return embed
@@ -248,6 +248,10 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         If the message has multiple embeds, you can pass a number to `index` to specify which embed.
         """
         await self.get_embed_from_message(message, index)
+        if not 0 <= index < len(message.embeds):
+            raise commands.BadArgument(
+                f"Index `{index}` is out of range. Expected `0` to `{len(message.embeds) - 1}`."
+            )
         view = EmbedBuilderView.from_embed(self, ctx.author, embeds=message.embeds, index=index)
         description = "Select the category and press the button below respectively to start creating/editing your embed."
         embed = discord.Embed(

--- a/embedmanager/embedmanager.py
+++ b/embedmanager/embedmanager.py
@@ -235,43 +235,6 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         fp = io.BytesIO(bytes(data, "utf-8"))
         await ctx.send(file=discord.File(fp, "embed.json"))
 
-    @embed_group.command(name="post", aliases=["view", "drop", "show"], invoke_without_command=True)
-    @checks.has_permissions(PermissionLevel.MODERATOR)
-    async def embed_post(
-        self,
-        ctx: commands.Context,
-        name: StoredEmbedConverter,
-        channel: MessageableChannel = None,
-    ):
-        """
-        Post a stored embed.
-
-        `name` must be a name that was used when storing the embed.
-        `channel` may be a channel name, ID, or mention.
-
-        Use command `{prefix}embed store list` to get the list of stored embeds.
-        """
-        channel = channel or ctx.channel
-        await channel.send(embed=discord.Embed.from_dict(name["embed"]))
-
-    @embed_group.command(name="info")
-    @checks.has_permissions(PermissionLevel.MODERATOR)
-    async def embed_info(self, ctx: commands.Context, name: StoredEmbedConverter):
-        """
-        Get info about an embed that is stored.
-
-        `name` must be a name that was used when storing the embed.
-
-        Use command `{prefix}embed store list` to get the list of stored embeds.
-        """
-        embed = discord.Embed(
-            title=f"`{name['name']}` Info",
-            description=(
-                f"Author: <@!{name['author']}>\n" f"Length: {len(discord.Embed.from_dict(name['embed']))}"
-            ),
-        )
-        await ctx.send(embed=embed)
-
     @embed_group.group(name="edit", invoke_without_command=True)
     @checks.has_permissions(PermissionLevel.MODERATOR)
     async def embed_edit(self, ctx: commands.Context, message: BotMessage, index: int = 0):
@@ -355,6 +318,43 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
         Store commands to store embeds for later use.
         """
         await ctx.send_help(ctx.command)
+
+    @embed_store.command(name="post", aliases=["view", "drop", "show"])
+    @checks.has_permissions(PermissionLevel.MODERATOR)
+    async def embed_store_post(
+        self,
+        ctx: commands.Context,
+        name: StoredEmbedConverter,
+        channel: MessageableChannel = None,
+    ):
+        """
+        Post a stored embed.
+
+        `name` must be a name that was used when storing the embed.
+        `channel` may be a channel name, ID, or mention.
+
+        Use command `{prefix}embed store list` to get the list of stored embeds.
+        """
+        channel = channel or ctx.channel
+        await channel.send(embed=discord.Embed.from_dict(name["embed"]))
+
+    @embed_store.command(name="info")
+    @checks.has_permissions(PermissionLevel.MODERATOR)
+    async def embed_store_info(self, ctx: commands.Context, name: StoredEmbedConverter):
+        """
+        Get info about an embed that is stored.
+
+        `name` must be a name that was used when storing the embed.
+
+        Use command `{prefix}embed store list` to get the list of stored embeds.
+        """
+        embed = discord.Embed(
+            title=f"`{name['name']}` Info",
+            description=(
+                f"Author: <@!{name['author']}>\n" f"Length: {len(discord.Embed.from_dict(name['embed']))}"
+            ),
+        )
+        await ctx.send(embed=embed)
 
     @embed_store.command(name="simple")
     @checks.has_permissions(PermissionLevel.MODERATOR)

--- a/embedmanager/embedmanager.py
+++ b/embedmanager/embedmanager.py
@@ -13,19 +13,6 @@ from core.models import PermissionLevel
 from core.paginator import EmbedPaginatorSession
 from core.utils import human_join
 
-from .core.builder import EmbedBuilderView
-from .core.converters import (
-    MessageableChannel,
-    BotMessage,
-    StoredEmbedConverter,
-    StringToEmbed,
-)
-from .core.data import JSON_EXAMPLE
-
-
-if TYPE_CHECKING:
-    from .motor.motor_asyncio import AsyncIOMotorCollection
-    from bot import ModmailBot
 
 info_json = Path(__file__).parent.resolve() / "info.json"
 with open(info_json, encoding="utf-8") as f:
@@ -46,8 +33,22 @@ except ImportError as exc:
         f"Install {required} plugin to resolve this issue."
     ) from exc
 
+from .core.converters import (
+    MessageableChannel,
+    BotMessage,
+    StoredEmbedConverter,
+    StringToEmbed,
+)
+from .core.data import JSON_EXAMPLE
+from .core.views import EmbedBuilderView
+
 
 # <!-- ----- -->
+
+
+if TYPE_CHECKING:
+    from .motor.motor_asyncio import AsyncIOMotorCollection
+    from bot import ModmailBot
 
 
 JSON_CONVERTER = StringToEmbed()

--- a/embedmanager/embedmanager.py
+++ b/embedmanager/embedmanager.py
@@ -146,7 +146,7 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
     @checks.has_permissions(PermissionLevel.MODERATOR)
     async def embed_build(self, ctx: commands.Context):
         """
-        Build embeds in an interactive mode using buttons and modal view.
+        Build embeds in an interactive mode using buttons and text input view.
         """
         description = "Select the category and press the button below respectively to start creating/editing your embed."
         embed = discord.Embed(
@@ -155,7 +155,6 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
             color=self.bot.main_color,
             timestamp=discord.utils.utcnow(),
         )
-        embed.set_footer(text="This panel will time out after 10 minutes.")
         view = EmbedBuilderView(self, ctx.author)
         view.message = await ctx.send(embed=embed, view=view)
         await view.wait()
@@ -257,7 +256,6 @@ class EmbedManager(commands.Cog, name=__plugin_name__):
             color=self.bot.main_color,
             timestamp=discord.utils.utcnow(),
         )
-        embed.set_footer(text="This panel will time out after 10 minutes.")
         view.message = await ctx.send(embed=embed, view=view)
         await view.wait()
 

--- a/embedmanager/info.json
+++ b/embedmanager/info.json
@@ -6,8 +6,8 @@
         "\n**Note:**\nThe JSON must be in the format expected by this [Discord documentation](https://discord.com/developers/docs/resources/channel#embed-object).",
         "\n**Version:**\n`{0}`"
     ],
-    "author": "Jerrie-Aries",
-    "version": "1.3.1",
+    "authors": ["Jerrie-Aries"],
+    "version": "1.3.2",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/embedmanager/info.json
+++ b/embedmanager/info.json
@@ -7,7 +7,7 @@
         "\n**Version:**\n`{0}`"
     ],
     "authors": ["Jerrie-Aries"],
-    "version": "1.3.2",
+    "version": "1.4.0",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]


### PR DESCRIPTION
This PR implements support for creating or editing multiple embeds in a single message.

### Changelog
- `builder.py` file is renamed to `views.py`. This is for consistency sake with my other plugins.
- Add `models.py` in `core` folder.
- Add a `New` button and `Embed` selector dropdown in embed builder/editor UI.
- Add support to customise embed timestamp.
- Editing fields now will post a new followup meesage with buttons.
- Move `?embed post` and `?embed info` to be subcommands of `?embed store`. Now the commands would be `?embed store post` and `?embed store info`.
