### PR TITLE
`supportutils` plugin v1.0.0: Thread move automation.

### DIFF
--- a/supportutils/core/config.py
+++ b/supportutils/core/config.py
@@ -48,6 +48,27 @@ _default_config: Dict[str, Any] = {
         "active_sessions": [],
         "rating": {"enable": False, "placeholder": "Choose a rating"},
     },
+    "thread_move": {
+        "enable": False,
+        "responded": {
+            "category": None,
+            "embed": {
+                "title": None,
+                "description": "This thread has been moved from {old_category} to {new_category}.",
+                "footer": None,
+            },
+        },
+        "inactive": {
+            "timeout": None,
+            "category": None,
+            "embed": {
+                "title": None,
+                "description": "This thread has been moved from {old_category} to {new_category} due to inactivity.",
+                "footer": None,
+            },
+            "tasks": {},
+        },
+    },
 }
 
 
@@ -62,3 +83,7 @@ class SupportUtilityConfig(Config):
     @property
     def feedback(self) -> Dict[str, Any]:
         return self["feedback"]
+
+    @property
+    def thread_move(self) -> Dict[str, Any]:
+        return self["thread_move"]

--- a/supportutils/core/models.py
+++ b/supportutils/core/models.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import Any, Dict, Optional, Set, Tuple, Union, TYPE_CHECKING
 
 import discord
+from discord.ext import tasks
 from discord.utils import MISSING
 
 from core.models import getLogger
@@ -12,14 +13,14 @@ from core.thread import Thread
 from .views import ContactView, FeedbackView
 
 
-logger = getLogger(__name__)
-
-
 if TYPE_CHECKING:
+    from datetime import datetime
     from bot import ModmailBot
     from ..supportutils import SupportUtility
     from .views import Modal
 
+
+logger = getLogger(__name__)
 
 ends_seconds: int = 60 * 60 * 24
 
@@ -375,6 +376,9 @@ class FeedbackManager:
         """
         return self.cog.config.feedback
 
+    def is_enabled(self) -> bool:
+        return self.config.get("enable")
+
     async def populate(self) -> None:
         """
         Populate active feedback sessions from database.
@@ -435,6 +439,39 @@ class FeedbackManager:
     def find_session(self, user: discord.Member) -> Optional[Feedback]:
         return next((fb for fb in self.active if fb.user == user), None)
 
+    async def handle_prompt(self, thread: Thread, *args: Any) -> None:
+        _, silent, *_ = args
+        if silent:
+            return
+
+        if not self.is_enabled():
+            return
+
+        for user in thread.recipients:
+            if user is None:
+                continue
+            if not isinstance(user, discord.Member):
+                entity = self.bot.guild.get_member(user.id)
+                if not entity:
+                    continue
+                user = entity
+            try:
+                await self.send(user, thread)
+            except RuntimeError:
+                pass
+
+    def clear_for(self, thread: Thread) -> None:
+        if not self.is_enabled():
+            return
+
+        for user in thread.recipients:
+            if user is None:
+                continue
+            feedback = self.find_session(user)
+            if feedback:
+                logger.debug(f"Stopping active feedback session for {user}.")
+                feedback.stop()
+
     async def send(self, user: discord.Member, thread: Optional[Thread] = None) -> None:
         """
         Sends the feedback prompt message to user and initiate the session.
@@ -463,3 +500,177 @@ class FeedbackManager:
         self.add(feedback)
         await self.cog.config.update()
         self.bot.loop.create_task(feedback.run())
+
+
+class ThreadMoveManager:
+    """
+    Represents an instance that handles moving responded and inactive threads to
+    designated category.
+    """
+
+    def __init__(self, cog: SupportUtility):
+        self.cog: SupportUtility = cog
+        self.bot: ModmailBot = cog.bot
+        self.inactivity_tasks: Dict[str, asyncio.Task] = {}
+        self._schedule_update: bool = False
+
+    async def initialize(self) -> None:
+        tasks = self.config["inactive"]["tasks"]
+        now = discord.utils.utcnow().timestamp()
+        for channel_id, ends_at in list(tasks.items()):
+            channel = self.bot.modmail_guild.get_channel(int(channel_id))
+            if channel is None or ends_at < now:
+                tasks.pop(channel_id)
+                self._schedule_update = True
+                continue
+            thread = await self.bot.threads.find(channel=channel)
+            if not thread:
+                tasks.pop(channel_id)
+                self._schedule_update = True
+                continue
+            timeout = ends_at - now
+            task = self.bot.loop.create_task(self.set_to_inactive_after(timeout, thread))
+            self.inactivity_tasks[channel_id] = task
+
+        self.update_loop.start()
+
+    def teardown(self) -> None:
+        self.update_loop.cancel()
+        for task in self.inactivity_tasks.values():
+            task.cancel()
+        self.inactivity_tasks.clear()
+
+    @property
+    def config(self) -> Dict[str, Any]:
+        return self.cog.config.thread_move
+
+    def is_enabled(self) -> bool:
+        return self.config.get("enable")
+
+    def _get_category(self, key: str) -> Optional[discord.CategoryChannel]:
+        category_id = self.config[key]["category"]
+        if category_id is None:
+            return None
+
+        category = self.bot.modmail_guild.get_channel(int(category_id))
+        if not isinstance(category, discord.CategoryChannel):
+            logger.error(
+                f"Invalid type of category. Expected CategoryChannel, got {type(category).__name__} instead."
+            )
+            category = None
+        return category
+
+    @property
+    def responded_category(self) -> Optional[discord.CategoryChannel]:
+        """
+        Category where the responded threads will be moved to.
+        """
+        return self._get_category("responded")
+
+    @property
+    def inactive_category(self) -> Optional[discord.CategoryChannel]:
+        """
+        Category where the inactive threads will be moved to.
+        """
+        return self._get_category("inactive")
+
+    async def handle_responded(self, thread: Thread) -> None:
+        if not self.is_enabled():
+            return
+        category = self.responded_category
+        if category is None or category == thread.channel.category:
+            return
+        await self._move_thread_channel(thread, category, event="responded")
+
+    async def _move_thread_channel(
+        self, thread: Thread, category: discord.CategoryChannel, *, event: str
+    ) -> None:
+        if event == "responded":
+            reason = "This thread has been responded."
+        elif event == "inactive":
+            reason = "This thread has been inactive."
+        else:
+            raise ValueError(f"Invalid type of move event. Got {event}.")
+
+        old_category = thread.channel.category
+        await thread.channel.move(category=category, end=True, sync_permissions=True, reason=reason)
+
+        description = self.bot.formatter.format(
+            self.config[event]["embed"]["description"],
+            old_category=old_category.mention if old_category else "unknown category",
+            new_category=category.mention,
+        )
+        embed = discord.Embed(
+            title=self.config[event]["embed"]["title"],
+            description=description,
+            color=self.bot.main_color,
+        )
+        footer_text = self.config[event]["embed"]["footer"]
+        if footer_text:
+            embed.set_footer(text=footer_text)
+        await thread.channel.send(embed=embed)
+
+    async def schedule_inactive_timer(self, thread: Thread, start_time: datetime) -> None:
+        channel_id = str(thread.channel.id)
+        # cancel existing task
+        await self.cancel_inactivity_task(channel_id)
+
+        if self.is_enabled() or not self.inactive_category:
+            return
+        timeout = self.config["inactive"]["timeout"]
+        if not timeout:
+            return
+
+        task = self.bot.loop.create_task(self.set_to_inactive_after(timeout, thread))
+        self.inactivity_tasks[channel_id] = task
+
+        after_timestamp = start_time.timestamp() + timeout
+        self.config["inactive"]["tasks"][channel_id] = after_timestamp
+        self._schedule_update = True
+
+    async def set_to_inactive_after(self, after: float, thread: Thread) -> None:
+        """
+        Set the thread to inactive. The thread will be moved to inactive category.
+
+        Note: This method should be created as a task with `bot.loop.create_task` and stored
+        in cache, so the task can be cancelled if the thread is responded.
+        """
+        await asyncio.sleep(after)
+        category = self.inactive_category
+        if category and category != thread.channel.category:
+            await self._move_thread_channel(thread, category, event="inactive")
+        await self.cancel_inactivity_task(thread.channel.id)
+
+    async def cancel_inactivity_task(self, channel_id: Union[int, str], force_update: bool = False) -> None:
+        """
+        Cancel or stop the inactivity task for thread specified.
+        """
+        channel_id = str(channel_id)
+        task = self.inactivity_tasks.pop(channel_id, None)
+        if task and not task.done():
+            task.cancel()
+        ends_at = self.config["inactive"]["tasks"].pop(channel_id, None)
+        # if this was in config, we need to resolve updating the config in db
+        if ends_at:
+            if force_update:
+                await self._update_inactive_tasks()
+            else:
+                self._schedule_update = True
+
+    # updating config everytime a message is sent in thread channel is quite expensive
+    # to prevent unnecessary API calls to database, we just do tasks.loop to handle it.
+    @tasks.loop(seconds=60)
+    async def update_loop(self) -> None:
+        if not self._schedule_update:
+            return
+        await self._update_inactive_tasks()
+
+    async def _update_inactive_tasks(self) -> None:
+        data = self.config["inactive"]["tasks"]
+        # we do manual insertion here so it won't touch other keys in the document
+        await self.cog.db.find_one_and_update(
+            {"_id": self.cog.config._id},
+            {"$set": {"thread_move.inactive.tasks": data}},
+            upsert=True,
+        )
+        self._schedule_update = False

--- a/supportutils/core/models.py
+++ b/supportutils/core/models.py
@@ -585,13 +585,10 @@ class ThreadMoveManager:
     async def _move_thread_channel(
         self, thread: Thread, category: discord.CategoryChannel, *, event: str
     ) -> None:
-        if event == "responded":
-            reason = "This thread has been responded."
-        elif event == "inactive":
-            reason = "This thread has been inactive."
-        else:
+        if event not in ("responded", "inactive"):
             raise ValueError(f"Invalid type of move event. Got {event}.")
 
+        reason = f"This thread has been {event}."
         old_category = thread.channel.category
         await thread.channel.move(category=category, end=True, sync_permissions=True, reason=reason)
 

--- a/supportutils/core/models.py
+++ b/supportutils/core/models.py
@@ -666,11 +666,7 @@ class ThreadMoveManager:
         await self._update_inactive_tasks()
 
     async def _update_inactive_tasks(self) -> None:
-        data = self.config["inactive"]["tasks"]
         # we do manual insertion here so it won't touch other keys in the document
-        await self.cog.db.find_one_and_update(
-            {"_id": self.cog.config._id},
-            {"$set": {"thread_move.inactive.tasks": data}},
-            upsert=True,
-        )
+        data = {"thread_move.inactive.tasks": self.config["inactive"]["tasks"]}
+        await self.cog.config.update(data=data)
         self._schedule_update = False

--- a/supportutils/core/models.py
+++ b/supportutils/core/models.py
@@ -615,7 +615,7 @@ class ThreadMoveManager:
         # cancel existing task
         await self.cancel_inactivity_task(channel_id)
 
-        if self.is_enabled() or not self.inactive_category:
+        if not self.is_enabled() or not self.inactive_category:
             return
         timeout = self.config["inactive"]["timeout"]
         if not timeout:

--- a/supportutils/info.json
+++ b/supportutils/info.json
@@ -2,13 +2,14 @@
     "name": "Support Utility",
     "description": [
         "Additional tools to enhance Support experience.\n",
-        "Contact Modmail using button and dropdown. Users submit their feedback after their thread is closed.",
-        "Customizable contact button, dropdown and message.",
-        "Link dropdown option to a specific category.",
+        "**Features:**",
+        "- Contact Modmail using button and dropdown. Customisable contact button, dropdown and message. Link the dropdown option to a specific category.",
+        "- Feedback and rating. Users submit their feedback after their thread is closed.",
+        "- Responded and inactive thread move automation.",
         "\n**Version:**\n`{0}`"
     ],
     "authors": ["Jerrie-Aries"],
-    "version": "0.5.1",
+    "version": "1.0.0",
     "bot_version": "4.0.0",
     "dpy_version": "2.0.0",
     "cogs_required": ["Extended Utils"]

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -1259,16 +1259,15 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         """
         await self._set_category_invoker(ctx, "responded", argument)
 
-    @tm_config_responded.command(
-        name="embed",
-        help=(
-            "Customise the embed title, description and footer text for responded thread move message.\n\n"
-            "Leave `argument` empty to set the values.\n"
-            "Set `argument` to `clear` or `reset` to restore the default value."
-        ),
-    )
+    @tm_config_responded.command(name="embed")
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def tm_config_responded_embed(self, ctx: commands.Context, *, argument: Optional[str] = None):
+        """
+        Customise the embed title, description and footer text for responded thread move message.
+
+        Leave `argument` empty to set the values.
+        Set `argument` to `clear` or `reset` to restore the default value.
+        """
         await self._set_embed_invoker(
             ctx,
             "responded thread move",
@@ -1344,16 +1343,15 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         """
         await self._set_category_invoker(ctx, "inactive", argument)
 
-    @tm_config_inactive.command(
-        name="embed",
-        help=(
-            "Customise the embed title, description and footer text for inactive thread move message.\n\n"
-            "Leave `argument` empty to set the values.\n"
-            "Set `argument` to `clear` or `reset` to restore the default value."
-        ),
-    )
+    @tm_config_inactive.command(name="embed")
     @checks.has_permissions(PermissionLevel.ADMINISTRATOR)
     async def tm_config_inactive_embed(self, ctx: commands.Context, *, argument: Optional[str] = None):
+        """
+        Customise the embed title, description and footer text for inactive thread move message.
+
+        Leave `argument` empty to set the values.
+        Set `argument` to `clear` or `reset` to restore the default value.
+        """
         await self._set_embed_invoker(
             ctx,
             "inactive thread move",
@@ -1407,8 +1405,8 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         Dispatched when the thread is closed.
         """
         tasks = [
-            self.bot.loop.create_task(self.feedback_manager.handle_prompt(thread, *args)),
             self.bot.loop.create_task(self.move_manager.cancel_inactivity_task(thread.channel.id, True)),
+            self.bot.loop.create_task(self.feedback_manager.handle_prompt(thread, *args)),
         ]
         await asyncio.gather(*tasks)
 
@@ -1417,8 +1415,8 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         manager = self.move_manager
         _, message, *_ = args
         tasks = [
-            self.bot.loop.create_task(manager.schedule_inactive_timer(thread, message.created_at)),
             self.bot.loop.create_task(manager.handle_responded(thread)),
+            self.bot.loop.create_task(manager.schedule_inactive_timer(thread, message.created_at)),
         ]
         await asyncio.gather(*tasks)
 

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -407,7 +407,8 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         if mode is None:
             embed = discord.Embed(
                 color=self.bot.main_color,
-                description=f"{name.capitalize()} feature is currently " + ("enabled." if enabled else "disabled."),
+                description=f"{name.capitalize()} feature is currently "
+                + ("enabled." if enabled else "disabled."),
             )
             return await ctx.send(embed=embed)
         if mode == enabled:

--- a/supportutils/supportutils.py
+++ b/supportutils/supportutils.py
@@ -1204,7 +1204,7 @@ class SupportUtility(commands.Cog, name=__plugin_name__):
         Thread move automation manager.
 
         This feature supports moving responded or inactive threads to designated category.
-        To enable this feature, just simply set a category for the ones you want to enable.
+        To enable this feature, just simply enable with command and set a category for the ones you want to enable.
 
         See `{prefix}threadmove config <subcommand>`
         """


### PR DESCRIPTION
This PR implements the automated of moving responded and inactive threads to designated category.

### Changelog
__**Added**__
- Responded and inactive thread move automation feature. This feature needs to be enabled first with `?threadmove config enable true` command. Then a category must be set for each one of responded and inactive, or any of the one you want to enable. Both categories cannot be the same. For inactive move feature, a timeout must be set and it cannot be lower than 10 minutes.

__**Internal**__
- Add `_set_embed_invoker`, `_set_button_invoker`, `_set_enable_invoker` and `_set_category_invoker` private methods. These are to handle multiple commands with similar callback.

As for me, the code is more readable than before.